### PR TITLE
feat: Offset for Item Display Blocks

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/ItemDisplayBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/ItemDisplayBlockEntity.java
@@ -33,6 +33,7 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 
 	public RotationType rotationType = RotationType.TRACKING;
 	public GivesItem givesItem = GivesItem.YES;
+	public Offset offset = Offset.CENTER;
 	public boolean showName = true;
 	public float pitch;
 	public float yaw;
@@ -58,6 +59,7 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 		tag.putFloat("yaw", this.yaw);
 		tag.putBoolean("show_name", this.showName);
 		tag.putString("gives_item", this.givesItem.name());
+		tag.putString("offset", this.offset.name());
 		NbtList given = new NbtList();
 		for (UUID id : givenTo) {
 			NbtCompound givenTag = new NbtCompound();
@@ -85,6 +87,12 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 			this.givesItem = GivesItem.valueOf(tag.getString("gives_item"));
 		} else {
 			this.givesItem = GivesItem.YES;
+		}
+
+		if (tag.contains("offset")) {
+			this.offset = Offset.valueOf(tag.getString("offset"));
+		} else {
+			this.offset = Offset.CENTER;
 		}
 
 		if (tag.contains("pitch")) {
@@ -170,6 +178,14 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 		}
 	}
 
+	public void cycleOffset() {
+		switch (this.offset) {
+			case CENTER -> this.offset = Offset.BACK;
+			case BACK -> this.offset = Offset.FRONT;
+			case FRONT -> this.offset = Offset.CENTER;
+		}
+	}
+
 	@Environment(EnvType.CLIENT)
 	public static Vec2f getPitchAndYaw(PlayerEntity player, BlockPos pos) {
 		double d = pos.getX() - player.getPos().x + 0.5;
@@ -196,5 +212,9 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 
 	public enum GivesItem {
 		YES, NO, ONCE
+	}
+
+	public enum Offset {
+		CENTER, BACK, FRONT
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/block/entity/TextBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/TextBlockEntity.java
@@ -26,7 +26,7 @@ import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 public class TextBlockEntity extends BlockEntity {
 	public List<MutableText> lines = new ArrayList<>();
 	public TextAlignment textAlignment = TextAlignment.CENTER;
-	public  ZOffset zOffset = ZOffset.CENTER;
+	public ZOffset zOffset = ZOffset.CENTER;
 	public ShadowType shadowType = ShadowType.DROP;
 	public float scale = 1F;
 	public int color = 0xFFFFFF;

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/ItemDisplayBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/ItemDisplayBlockEditScreen.java
@@ -14,6 +14,7 @@ public class ItemDisplayBlockEditScreen extends GlowcaseScreen {
 	private ButtonWidget givesItemButtom;
 	private ButtonWidget rotationTypeButton;
 	private ButtonWidget showNameButton;
+	private ButtonWidget offsetButton;
 
 	public ItemDisplayBlockEditScreen(ItemDisplayBlockEntity displayBlock) {
 		this.displayBlock = displayBlock;
@@ -29,27 +30,34 @@ public class ItemDisplayBlockEditScreen extends GlowcaseScreen {
 			int centerW = width / 2;
 			int centerH = height / 2;
 
-			this.givesItemButtom = new ButtonWidget(centerW - 75, centerH - 30 - individualPadding, 150, 20, Text.translatable("gui.glowcase.gives_item", this.displayBlock.givesItem), (action) -> {
+			this.givesItemButtom = new ButtonWidget(centerW - 75, centerH - 40 - individualPadding, 150, 20, Text.translatable("gui.glowcase.gives_item", this.displayBlock.givesItem), (action) -> {
 				this.displayBlock.cycleGiveType();
 				this.givesItemButtom.setMessage(Text.translatable("gui.glowcase.gives_item", this.displayBlock.givesItem));
 				ItemDisplayBlockChannel.sync(this.displayBlock, true);
 			});
 
-			this.rotationTypeButton = new ButtonWidget(centerW - 75, centerH - 10, 150, 20, Text.translatable("gui.glowcase.rotation_type", this.displayBlock.rotationType), (action) -> {
+			this.rotationTypeButton = new ButtonWidget(centerW - 75, centerH - 20, 150, 20, Text.translatable("gui.glowcase.rotation_type", this.displayBlock.rotationType), (action) -> {
 				this.displayBlock.cycleRotationType(this.client.player);
 				this.rotationTypeButton.setMessage(Text.translatable("gui.glowcase.rotation_type", this.displayBlock.rotationType));
 				ItemDisplayBlockChannel.sync(this.displayBlock, true);
 			});
 
-			this.showNameButton = new ButtonWidget(centerW - 75, centerH + 10 + individualPadding, 150, 20, Text.translatable("gui.glowcase.show_name", this.displayBlock.showName), (action) -> {
+			this.showNameButton = new ButtonWidget(centerW - 75, centerH + individualPadding, 150, 20, Text.translatable("gui.glowcase.show_name", this.displayBlock.showName), (action) -> {
 				this.displayBlock.showName = !this.displayBlock.showName;
 				this.showNameButton.setMessage(Text.translatable("gui.glowcase.show_name", this.displayBlock.showName));
 				ItemDisplayBlockChannel.sync(this.displayBlock, false);
 			});
 
+			this.offsetButton = new ButtonWidget(centerW - 75, centerH + 20 + padding, 150, 20, Text.translatable("gui.glowcase.offset", this.displayBlock.offset), (action) -> {
+				this.displayBlock.cycleOffset();
+				this.offsetButton.setMessage(Text.translatable("gui.glowcase.offset", this.displayBlock.offset));
+				ItemDisplayBlockChannel.sync(this.displayBlock, true);
+			});
+
 			this.addDrawableChild(this.givesItemButtom);
 			this.addDrawableChild(this.rotationTypeButton);
 			this.addDrawableChild(this.showNameButton);
+			this.addDrawableChild(this.offsetButton);
 		}
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/ItemDisplayBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/ItemDisplayBlockEntityRenderer.java
@@ -54,6 +54,11 @@ public record ItemDisplayBlockEntityRenderer(BlockEntityRendererFactory.Context 
 			}
 		}
 
+		switch (entity.offset) {
+			case FRONT -> matrices.translate(0D, Math.sin(pitch) * 0.4, -0.4D);
+			case BACK -> matrices.translate(0D, Math.sin(pitch) * -0.4, 0.4D);
+		}
+
 		ItemStack stack = entity.getUseStack();
 		Text name;
 		if (stack.getItem() instanceof SpawnEggItem) {

--- a/src/main/java/dev/hephaestus/glowcase/networking/ItemDisplayBlockChannel.java
+++ b/src/main/java/dev/hephaestus/glowcase/networking/ItemDisplayBlockChannel.java
@@ -37,6 +37,7 @@ public class ItemDisplayBlockChannel implements ModInitializer, ClientModInitial
         buf.writeBlockPos(itemDisplayBlockEntity.getPos());
         buf.writeEnumConstant(itemDisplayBlockEntity.rotationType);
         buf.writeEnumConstant(itemDisplayBlockEntity.givesItem);
+        buf.writeEnumConstant(itemDisplayBlockEntity.offset);
         buf.writeVarInt(itemDisplayBlockEntity.getCachedState().get(Properties.ROTATION));
         buf.writeBoolean(itemDisplayBlockEntity.showName);
 
@@ -79,6 +80,7 @@ public class ItemDisplayBlockChannel implements ModInitializer, ClientModInitial
         BlockPos pos = buf.readBlockPos();
         ItemDisplayBlockEntity.RotationType rotationType = buf.readEnumConstant(ItemDisplayBlockEntity.RotationType.class);
         ItemDisplayBlockEntity.GivesItem givesItem = buf.readEnumConstant(ItemDisplayBlockEntity.GivesItem.class);
+        ItemDisplayBlockEntity.Offset offset = buf.readEnumConstant(ItemDisplayBlockEntity.Offset.class);
         int rotation = buf.readVarInt();
         boolean showName = buf.readBoolean();
 
@@ -89,6 +91,7 @@ public class ItemDisplayBlockChannel implements ModInitializer, ClientModInitial
             if (player.world.getBlockEntity(pos) instanceof ItemDisplayBlockEntity be) {
                 be.givesItem = givesItem;
                 be.rotationType = rotationType;
+                be.offset = offset;
                 be.pitch = pitch;
                 be.yaw = yaw;
                 be.showName = showName;

--- a/src/main/resources/assets/glowcase/lang/en_us.json
+++ b/src/main/resources/assets/glowcase/lang/en_us.json
@@ -10,6 +10,7 @@
   "gui.glowcase.shadow_type": "Shadow Type",
   "gui.glowcase.rotation_type": "Rotation Type: %s",
   "gui.glowcase.show_name": "Show Name: %s",
+  "gui.glowcase.offset": "Offset: %s",
   "gui.glowcase.none": "(None)",
   "item.glowcase.text_block": "Text Block",
   "item.glowcase.hyperlink_block": "Hyperlink Block",


### PR DESCRIPTION
Allows Item Display Blocks to be offset similar to Text Blocks.
Mostly inspired by some use cases during Singularity, making Item Display Blocks a better alternative to Item Frames.

![image](https://user-images.githubusercontent.com/10999535/193566367-9f076adb-6cdf-4fc2-919e-660f785ff1d6.png)
