### PR TITLE
fix: item display block rendering entities for spawn eggs

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/ItemDisplayBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/ItemDisplayBlockEntity.java
@@ -72,6 +72,7 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 		super.readNbt(tag);
 
 		this.stack = ItemStack.fromNbt(tag.getCompound("item"));
+		this.clearDisplayEntity();
 
 		if (tag.contains("tracking")) {
 			this.rotationType = tag.getBoolean("tracking") ? RotationType.TRACKING : RotationType.LOCKED;
@@ -128,20 +129,20 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 
 		this.givenTo.clear();
 
-		this.setDisplayEntity();
+		this.clearDisplayEntity();
 
 		this.markDirty();
 	}
 
-	private void setDisplayEntity() {
-		if (this.stack.getItem() instanceof SpawnEggItem) {
-			this.displayEntity = ((SpawnEggItem) this.stack.getItem()).getEntityType(this.stack.getNbt()).create(this.world);
-		} else {
-			this.displayEntity = null;
-		}
+	private void clearDisplayEntity() {
+		this.displayEntity = null;
 	}
 
 	public Entity getDisplayEntity() {
+		if (this.displayEntity == null && this.world != null && this.stack.getItem() instanceof SpawnEggItem eggItem) {
+			this.displayEntity = eggItem.getEntityType(this.stack.getNbt()).create(this.world);
+		}
+
 		return this.displayEntity;
 	}
 
@@ -184,7 +185,7 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 	}
 
 	public static void tick(World world, BlockPos blockPos, BlockState state, ItemDisplayBlockEntity blockEntity) {
-		if (blockEntity.displayEntity != null) {
+		if (blockEntity.getDisplayEntity() != null) {
 			blockEntity.displayEntity.tick();
 			++blockEntity.displayEntity.age;
 		}


### PR DESCRIPTION
# Motivation

See #2. Spawn eggs are meant to render in item display blocks as their entity. Instead, nothing renders.

# Content

Changes the code in `ItemDisplayBlockEntity` to ensure that the display entity is present if needed when `getDisplayEntity` is run. Also guards against an NPE when `this.world` is null.