### PR TITLE
Item Tracking Using Camera Entity

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/ItemDisplayBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/ItemDisplayBlockEntity.java
@@ -194,10 +194,10 @@ public class ItemDisplayBlockEntity extends BlockEntity {
 	}
 
 	@Environment(EnvType.CLIENT)
-	public static Vec2f getPitchAndYaw(PlayerEntity player, BlockPos pos) {
-		double d = pos.getX() - player.getPos().x + 0.5;
-		double e = pos.getY() - player.getEyeY() + 0.5;
-		double f = pos.getZ() - player.getPos().z + 0.5;
+	public static Vec2f getPitchAndYaw(Entity camera, BlockPos pos) {
+		double d = pos.getX() - camera.getPos().x + 0.5;
+		double e = pos.getY() - camera.getEyeY() + 0.5;
+		double f = pos.getZ() - camera.getPos().z + 0.5;
 		double g = MathHelper.sqrt((float) (d * d + f * f));
 
 		float pitch = (float) ((-MathHelper.atan2(e, g)));

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/ItemDisplayBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/ItemDisplayBlockEntityRenderer.java
@@ -13,7 +13,6 @@ import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraft.state.property.Properties;
@@ -28,9 +27,9 @@ public record ItemDisplayBlockEntityRenderer(BlockEntityRendererFactory.Context 
 
 	@Override
 	public void render(ItemDisplayBlockEntity entity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
-		PlayerEntity player = mc.player;
+		Entity camera = mc.getCameraEntity();
 
-		if (player == null) return;
+		if (camera == null) return;
 
 		matrices.push();
 		matrices.translate(0.5D, 0D, 0.5D);
@@ -40,7 +39,7 @@ public record ItemDisplayBlockEntityRenderer(BlockEntityRendererFactory.Context 
 
 		switch (entity.rotationType) {
 			case TRACKING -> {
-				Vec2f pitchAndYaw = ItemDisplayBlockEntity.getPitchAndYaw(player, entity.getPos());
+				Vec2f pitchAndYaw = ItemDisplayBlockEntity.getPitchAndYaw(camera, entity.getPos());
 				pitch = pitchAndYaw.x;
 				yaw = pitchAndYaw.y;
 				matrices.multiply(RotationAxis.POSITIVE_Y.rotation(yaw));

--- a/src/main/java/dev/hephaestus/glowcase/networking/GlowcaseClientNetworking.java
+++ b/src/main/java/dev/hephaestus/glowcase/networking/GlowcaseClientNetworking.java
@@ -28,8 +28,8 @@ public class GlowcaseClientNetworking {
 		buf.writeVarInt(be.getCachedState().get(Properties.ROTATION));
 		buf.writeBoolean(be.showName);
 
-		if (updatePitchAndYaw && MinecraftClient.getInstance().player != null) {
-			Vec2f pitchAndYaw = ItemDisplayBlockEntity.getPitchAndYaw(MinecraftClient.getInstance().player, be.getPos());
+		if (updatePitchAndYaw && MinecraftClient.getInstance().getCameraEntity() != null) {
+			Vec2f pitchAndYaw = ItemDisplayBlockEntity.getPitchAndYaw(MinecraftClient.getInstance().getCameraEntity(), be.getPos());
 			be.pitch = pitchAndYaw.x;
 			be.yaw = pitchAndYaw.y;
 		}


### PR DESCRIPTION
Closes #14

Changes the item tracking logic to use the current camera entity rather than the player. This fixes an edge case when the player's position doesn't update because the tracking entity in spectator mode is moving.