### PR TITLE
Sprite Block Scale and Item Rendering

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/SpriteBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/SpriteBlockEntity.java
@@ -2,15 +2,24 @@ package dev.hephaestus.glowcase.block.entity;
 
 import dev.hephaestus.glowcase.Glowcase;
 import net.minecraft.block.BlockState;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 public class SpriteBlockEntity extends GlowcaseBlockEntity {
-	public String sprite = "arrow";
+	protected String sprite = "arrow";
+	protected @Nullable ItemStack renderItem = null;
 	public int rotation = 0;
 	public TextBlockEntity.ZOffset zOffset = TextBlockEntity.ZOffset.BACK;
 	public int color = 0xFFFFFF;
+	public float scale = 1;
 
 	public SpriteBlockEntity(BlockPos pos, BlockState state) {
 		super(Glowcase.SPRITE_BLOCK_ENTITY.get(), pos, state);
@@ -18,7 +27,21 @@ public class SpriteBlockEntity extends GlowcaseBlockEntity {
 
 	public void setSprite(String newSprite) {
 		sprite = newSprite;
-		markDirty();
+		if (newSprite.contains(":")) {
+			Optional<Item> item = Registries.ITEM.getOrEmpty(Identifier.tryParse(newSprite));
+			renderItem = item.map(ItemStack::new).orElse(null);
+		} else {
+			renderItem = null;
+		}
+	}
+
+	public String getSprite() {
+		return sprite;
+	}
+
+	@Nullable
+	public ItemStack getRenderItem() {
+		return renderItem;
 	}
 
 	@Override
@@ -29,16 +52,18 @@ public class SpriteBlockEntity extends GlowcaseBlockEntity {
 		tag.putInt("rotation", this.rotation);
 		tag.putString("z_offset", this.zOffset.name());
 		tag.putInt("color", this.color);
+		tag.putFloat("scale", this.scale);
 	}
 
 	@Override
 	public void readNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
 		super.readNbt(tag, registryLookup);
 
-		this.sprite = tag.getString("sprite");
+		setSprite(tag.getString("sprite"));
 		this.rotation = tag.getInt("rotation");
 		this.zOffset = TextBlockEntity.ZOffset.valueOf(tag.getString("z_offset"));
 		this.color = tag.getInt("color");
+		this.scale = tag.getFloat("scale");
 	}
 
 	public void setRotation(int rotation) {

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
@@ -5,6 +5,7 @@ import dev.hephaestus.glowcase.block.entity.TextBlockEntity;
 import dev.hephaestus.glowcase.packet.C2SEditSpriteBlock;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
 import net.minecraft.util.Identifier;
@@ -16,6 +17,7 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 	private ButtonWidget rotationWidget;
 	private ButtonWidget zOffsetToggle;
 	private TextFieldWidget colorEntryWidget;
+	private TextFieldWidget scaleEntryWidget;
 
 	public SpriteBlockEditScreen(SpriteBlockEntity spriteBlockEntity) {
 		this.spriteBlockEntity = spriteBlockEntity;
@@ -28,10 +30,11 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 		if (this.client == null) return;
 
 		this.spriteWidget = new TextFieldWidget(this.client.textRenderer, width / 2 - 75, height / 2 - 55, 150, 20, Text.empty());
-		this.spriteWidget.setText(spriteBlockEntity.sprite);
+		this.spriteWidget.setText(spriteBlockEntity.getSprite());
 		this.spriteWidget.setChangedListener(string -> {
-			if (Identifier.isPathValid(this.spriteWidget.getText())) {
-				this.spriteBlockEntity.sprite = this.spriteWidget.getText();
+			if (Identifier.isPathValid(this.spriteWidget.getText()) ||
+				this.spriteWidget.getText().contains(":") && Registries.ITEM.containsId(Identifier.tryParse(this.spriteWidget.getText()))) {
+				this.spriteBlockEntity.setSprite(this.spriteWidget.getText());
 			}
 		});
 
@@ -57,15 +60,25 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 			});
 		});
 
+		this.scaleEntryWidget = new TextFieldWidget(this.client.textRenderer, width / 2 - 75, height / 2 + 65, 150, 20, Text.empty());
+		this.scaleEntryWidget.setText(String.valueOf(this.spriteBlockEntity.scale));
+		this.scaleEntryWidget.setChangedListener(string -> {
+			 try {
+				 this.spriteBlockEntity.scale = Float.parseFloat(string);
+			 } catch (NumberFormatException ignored) {}
+		});
+
 		this.addDrawableChild(this.spriteWidget);
 		this.addDrawableChild(this.rotationWidget);
 		this.addDrawableChild(this.zOffsetToggle);
 		this.addDrawableChild(this.colorEntryWidget);
+		this.addDrawableChild(this.scaleEntryWidget);
 	}
 
 	@Override
 	public void close() {
 		spriteBlockEntity.setSprite(spriteWidget.getText());
+		spriteBlockEntity.markDirty();
 		C2SEditSpriteBlock.of(spriteBlockEntity).send();
 		super.close();
 	}

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
@@ -12,6 +12,7 @@ import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.texture.TextureManager;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.resource.ResourceManager;
@@ -43,32 +44,39 @@ public record SpriteBlockEntityRenderer(BlockEntityRendererFactory.Context conte
 			case BACK -> matrices.translate(0D, 0D, -0.4D);
 		}
 
+		matrices.scale(entity.scale, entity.scale, entity.scale);
+
 		var entry = matrices.peek();
-		Identifier identifier = Identifier.tryParse(Glowcase.MODID, "textures/sprite/" + entity.sprite + ".png");
-		if (identifier == null) {
-			identifier = Glowcase.id("textures/sprite/invalid.png");
+		if (entity.getRenderItem() != null) {
+			MinecraftClient.getInstance().getItemRenderer().renderItem(entity.getRenderItem(),
+				ModelTransformationMode.FIXED, light, overlay, matrices, vertexConsumers, entity.getWorld(), 0);
 		} else {
-			TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
-			ResourceManager resourceManager = ((TextureManagerAccessor) textureManager).glowcase$getResourceManager();
-			if (resourceManager.getResource(identifier).isEmpty()) {
+			Identifier identifier = Identifier.tryParse(Glowcase.MODID, "textures/sprite/" + entity.getSprite() + ".png");
+			if (identifier == null) {
+				identifier = Glowcase.id("textures/sprite/invalid.png");
+			} else {
+				TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
+				ResourceManager resourceManager = ((TextureManagerAccessor) textureManager).glowcase$getResourceManager();
+				if (resourceManager.getResource(identifier).isEmpty()) {
 				/*
 				If the texture (file) does not exist, just replace it.
 				This happens a lot when editing a sprite block, so I'm adding it to avoid log spam
 				- SkyNotTheLimit
 				 */
-				identifier = Glowcase.id("textures/sprite/invalid.png");
+					identifier = Glowcase.id("textures/sprite/invalid.png");
+				}
 			}
-		}
-		var vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(identifier));
+			var vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(identifier));
 
-		vertex(entry, vertexConsumer, vertices[0], 0, 1, entity.color);
-		vertex(entry, vertexConsumer, vertices[1], 1, 1, entity.color);
-		vertex(entry, vertexConsumer, vertices[2], 1, 0, entity.color);
-		vertex(entry, vertexConsumer, vertices[3], 0, 0, entity.color);
+			vertex(entry, vertexConsumer, vertices[0], 0, 1, entity.color);
+			vertex(entry, vertexConsumer, vertices[1], 1, 1, entity.color);
+			vertex(entry, vertexConsumer, vertices[2], 1, 0, entity.color);
+			vertex(entry, vertexConsumer, vertices[3], 0, 0, entity.color);
+		}
 
 		matrices.pop();
 
-		if (entity.sprite.isEmpty() || BlockEntityRenderUtil.shouldRenderPlaceholder(entity.getPos())) BlockEntityRenderUtil.renderFacingPlaceholder(entity, ITEM_TEXTURE, 1.0F, matrices, vertexConsumers);
+		if (entity.getSprite().isEmpty() || BlockEntityRenderUtil.shouldRenderPlaceholder(entity.getPos())) BlockEntityRenderUtil.renderFacingPlaceholder(entity, ITEM_TEXTURE, 1.0F, matrices, vertexConsumers);
 	}
 
 	private void vertex(

--- a/src/main/java/dev/hephaestus/glowcase/packet/C2SEditSpriteBlock.java
+++ b/src/main/java/dev/hephaestus/glowcase/packet/C2SEditSpriteBlock.java
@@ -11,7 +11,7 @@ import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 
-public record C2SEditSpriteBlock(BlockPos pos, String sprite, int rotation, TextBlockEntity.ZOffset offset, int color) implements C2SEditBlockEntity {
+public record C2SEditSpriteBlock(BlockPos pos, String sprite, int rotation, TextBlockEntity.ZOffset offset, int color, float scale) implements C2SEditBlockEntity {
 	public static final Id<C2SEditSpriteBlock> ID = new Id<>(Glowcase.id("channel.sprite.save"));
 	public static final PacketCodec<RegistryByteBuf, C2SEditSpriteBlock> PACKET_CODEC = PacketCodec.tuple(
 		BlockPos.PACKET_CODEC, C2SEditSpriteBlock::pos,
@@ -19,11 +19,12 @@ public record C2SEditSpriteBlock(BlockPos pos, String sprite, int rotation, Text
 		PacketCodecs.INTEGER, C2SEditSpriteBlock::rotation,
 		PacketCodecs.INTEGER.xmap(index -> TextBlockEntity.ZOffset.values()[index], TextBlockEntity.ZOffset::ordinal), C2SEditSpriteBlock::offset,
 		PacketCodecs.INTEGER, C2SEditSpriteBlock::color,
+		PacketCodecs.FLOAT, C2SEditSpriteBlock::scale,
 		C2SEditSpriteBlock::new
 	);
 
 	public static C2SEditSpriteBlock of(SpriteBlockEntity be) {
-		return new C2SEditSpriteBlock(be.getPos(), be.sprite, be.rotation, be.zOffset, be.color);
+		return new C2SEditSpriteBlock(be.getPos(), be.getSprite(), be.rotation, be.zOffset, be.color, be.scale);
 	}
 
 	@Override
@@ -39,6 +40,7 @@ public record C2SEditSpriteBlock(BlockPos pos, String sprite, int rotation, Text
 		be.rotation = this.rotation();
 		be.zOffset = this.offset();
 		be.color = this.color();
+		be.scale = this.scale();
 
 		be.markDirty();
 	}


### PR DESCRIPTION
Adds functionality to adjust the scale of the sprite block and to allow rendering items in sprite blocks. Note that item rendering requires a `:` in the sprite name (meaning the namespace must be provided), to prevent something like `arrow` from being parsed as the `minecraft:arrow` item.

Contributes to #78 