### PR TITLE
fix sky color bleeding into EMI Recipe Block rendering

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/util/EmiClientUtils.java
+++ b/src/main/java/dev/hephaestus/glowcase/util/EmiClientUtils.java
@@ -121,6 +121,9 @@ public class EmiClientUtils {
 		view.translate(0.0f, 0.0f, 10.0f);
 		RenderSystem.applyModelViewMatrix();
 
+		float originalFogEnd = RenderSystem.getShaderFogEnd();
+		RenderSystem.setShaderFogEnd(Float.MAX_VALUE);
+
 		Matrix4f backupProj = RenderSystem.getProjectionMatrix();
 		RenderSystem.setProjectionMatrix(new Matrix4f().identity(), VertexSorter.BY_Z);
 		GlowcaseWidgetHolder holder = new GlowcaseWidgetHolder(recipe.getDisplayWidth(), recipe.getDisplayHeight());
@@ -145,6 +148,7 @@ public class EmiClientUtils {
 		SORRY.getEntityVertexConsumers().draw();
 
 		framebuffer.endWrite();
+		RenderSystem.setShaderFogEnd(originalFogEnd);
 		client.getFramebuffer().beginWrite(true);
 		return framebuffer;
 	}


### PR DESCRIPTION
Recipe Block rendering, unlike any `BakedBlockEntityRenderer` did not previously override the shader fog end while doing framebuffer rendering, leading to visual issues:
![image](https://github.com/user-attachments/assets/0b3cb5f7-0fb7-42ab-8934-a261b60b6cf1)
