### PR TITLE
Sprite Block Add Support for Texture and Mod Icon

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
@@ -33,10 +33,7 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 		this.spriteWidget.setMaxLength(255);
 		this.spriteWidget.setText(spriteBlockEntity.getSprite());
 		this.spriteWidget.setChangedListener(string -> {
-			if (Identifier.isPathValid(this.spriteWidget.getText()) ||
-				this.spriteWidget.getText().contains(":") && Registries.ITEM.containsId(Identifier.tryParse(this.spriteWidget.getText()))) {
-				this.spriteBlockEntity.setSprite(this.spriteWidget.getText());
-			}
+			this.spriteBlockEntity.setSprite(this.spriteWidget.getText());
 		});
 
 		this.rotationWidget = ButtonWidget.builder(Text.translatable("gui.glowcase.rotate"), (action) -> {

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
@@ -23,12 +23,12 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 	private final SpriteBlockEntity spriteBlockEntity;
 
 	private TextFieldWidget spriteWidget;
+	private ButtonWidget spriteWidgetHelpButton;
 	private ButtonWidget rotationWidget;
 	private ButtonWidget zOffsetToggle;
 	private TextFieldWidget colorEntryWidget;
 	private TextFieldWidget scaleEntryWidget;
 
-	private TooltipPositioner spriteHelpTooltipPositioner;
 	private List<OrderedText> spriteHelpTooltipText;
 
 	public SpriteBlockEditScreen(SpriteBlockEntity spriteBlockEntity) {
@@ -48,11 +48,12 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 			this.spriteBlockEntity.setSprite(this.spriteWidget.getText());
 		});
 
-		this.spriteHelpTooltipPositioner = new ConstantTooltipPositioner(new Vector2i(
-			SpriteBlockEditScreen.this.spriteWidget.getX() + SpriteBlockEditScreen.this.spriteWidget.getWidth() + 8,
-			SpriteBlockEditScreen.this.spriteWidget.getY() - 16
-		));
-		this.spriteHelpTooltipText = this.client.textRenderer.wrapLines(Text.translatable("gui.glowcase.screen.sprite_edit.sprite"), 125);
+		this.spriteWidgetHelpButton = ButtonWidget.builder(Text.literal("?"), action -> {})
+			.dimensions(spriteWidget.getX() + spriteWidget.getWidth() + 4, spriteWidget.getY(),
+				spriteWidget.getHeight(), spriteWidget.getHeight())
+			.build();
+
+		this.spriteHelpTooltipText = Tooltip.wrapLines(this.client, Text.translatable("gui.glowcase.screen.sprite_edit.sprite"));
 
 		this.rotationWidget = ButtonWidget.builder(Text.translatable("gui.glowcase.rotate"), (action) -> {
 			this.spriteBlockEntity.rotation = (this.spriteBlockEntity.rotation + 45) % 360;
@@ -85,6 +86,7 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 		});
 
 		this.addDrawableChild(this.spriteWidget);
+		this.addDrawableChild(this.spriteWidgetHelpButton);
 		this.addDrawableChild(this.rotationWidget);
 		this.addDrawableChild(this.zOffsetToggle);
 		this.addDrawableChild(this.colorEntryWidget);
@@ -94,8 +96,10 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 	@Override
 	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
 		super.render(context, mouseX, mouseY, delta);
-		if (this.spriteWidget.isHovered() || (this.spriteWidget.isFocused() && this.client.getNavigationType().isKeyboard())) {
-			setTooltip(this.spriteHelpTooltipText, this.spriteHelpTooltipPositioner, this.spriteWidget.isFocused());
+		// Tooltip is handled this way, since setting the tooltip directly on the help button widget causes the tooltip
+		// to clip off-screen at higher GUI scales.
+		if (this.spriteWidgetHelpButton.isHovered() || (this.spriteWidgetHelpButton.isFocused() && this.client.getNavigationType().isKeyboard())) {
+			setTooltip(this.spriteHelpTooltipText);
 		}
 	}
 
@@ -105,12 +109,5 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 		spriteBlockEntity.markDirty();
 		C2SEditSpriteBlock.of(spriteBlockEntity).send();
 		super.close();
-	}
-
-	record ConstantTooltipPositioner(Vector2ic position) implements TooltipPositioner {
-		@Override
-		public Vector2ic getPosition(int screenWidth, int screenHeight, int x, int y, int width, int height) {
-			return position;
-		}
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
@@ -30,6 +30,7 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 		if (this.client == null) return;
 
 		this.spriteWidget = new TextFieldWidget(this.client.textRenderer, width / 2 - 75, height / 2 - 55, 150, 20, Text.empty());
+		this.spriteWidget.setMaxLength(255);
 		this.spriteWidget.setText(spriteBlockEntity.getSprite());
 		this.spriteWidget.setChangedListener(string -> {
 			if (Identifier.isPathValid(this.spriteWidget.getText()) ||

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
@@ -3,6 +3,7 @@ package dev.hephaestus.glowcase.client.gui.screen.ingame;
 import dev.hephaestus.glowcase.block.entity.SpriteBlockEntity;
 import dev.hephaestus.glowcase.block.entity.TextBlockEntity;
 import dev.hephaestus.glowcase.packet.C2SEditSpriteBlock;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.tooltip.TooltipPositioner;
@@ -93,7 +94,9 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 	@Override
 	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
 		super.render(context, mouseX, mouseY, delta);
-		context.drawTooltip(this.textRenderer, this.spriteHelpTooltipText, this.spriteHelpTooltipPositioner, 0, 0);
+		if (this.spriteWidget.isHovered() || (this.spriteWidget.isFocused() && this.client.getNavigationType().isKeyboard())) {
+			setTooltip(this.spriteHelpTooltipText, this.spriteHelpTooltipPositioner, this.spriteWidget.isFocused());
+		}
 	}
 
 	@Override

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/SpriteBlockEditScreen.java
@@ -3,12 +3,20 @@ package dev.hephaestus.glowcase.client.gui.screen.ingame;
 import dev.hephaestus.glowcase.block.entity.SpriteBlockEntity;
 import dev.hephaestus.glowcase.block.entity.TextBlockEntity;
 import dev.hephaestus.glowcase.packet.C2SEditSpriteBlock;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.tooltip.TooltipPositioner;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.registry.Registries;
+import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
 import net.minecraft.util.Identifier;
+import org.joml.Vector2i;
+import org.joml.Vector2ic;
+
+import java.util.List;
 
 public class SpriteBlockEditScreen extends GlowcaseScreen {
 	private final SpriteBlockEntity spriteBlockEntity;
@@ -18,6 +26,9 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 	private ButtonWidget zOffsetToggle;
 	private TextFieldWidget colorEntryWidget;
 	private TextFieldWidget scaleEntryWidget;
+
+	private TooltipPositioner spriteHelpTooltipPositioner;
+	private List<OrderedText> spriteHelpTooltipText;
 
 	public SpriteBlockEditScreen(SpriteBlockEntity spriteBlockEntity) {
 		this.spriteBlockEntity = spriteBlockEntity;
@@ -35,6 +46,12 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 		this.spriteWidget.setChangedListener(string -> {
 			this.spriteBlockEntity.setSprite(this.spriteWidget.getText());
 		});
+
+		this.spriteHelpTooltipPositioner = new ConstantTooltipPositioner(new Vector2i(
+			SpriteBlockEditScreen.this.spriteWidget.getX() + SpriteBlockEditScreen.this.spriteWidget.getWidth() + 8,
+			SpriteBlockEditScreen.this.spriteWidget.getY() - 16
+		));
+		this.spriteHelpTooltipText = this.client.textRenderer.wrapLines(Text.translatable("gui.glowcase.screen.sprite_edit.sprite"), 125);
 
 		this.rotationWidget = ButtonWidget.builder(Text.translatable("gui.glowcase.rotate"), (action) -> {
 			this.spriteBlockEntity.rotation = (this.spriteBlockEntity.rotation + 45) % 360;
@@ -74,10 +91,23 @@ public class SpriteBlockEditScreen extends GlowcaseScreen {
 	}
 
 	@Override
+	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+		super.render(context, mouseX, mouseY, delta);
+		context.drawTooltip(this.textRenderer, this.spriteHelpTooltipText, this.spriteHelpTooltipPositioner, 0, 0);
+	}
+
+	@Override
 	public void close() {
 		spriteBlockEntity.setSprite(spriteWidget.getText());
 		spriteBlockEntity.markDirty();
 		C2SEditSpriteBlock.of(spriteBlockEntity).send();
 		super.close();
+	}
+
+	record ConstantTooltipPositioner(Vector2ic position) implements TooltipPositioner {
+		@Override
+		public Vector2ic getPosition(int screenWidth, int screenHeight, int x, int y, int width, int height) {
+			return position;
+		}
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
@@ -62,31 +62,40 @@ public record SpriteBlockEntityRenderer(BlockEntityRendererFactory.Context conte
 				ModelTransformationMode.FIXED, light, overlay, matrices, vertexConsumers, entity.getWorld(), 0);
 		} else {
 			Identifier identifier = Identifier.tryParse(Glowcase.MODID, "textures/sprite/" + entity.getSprite() + ".png");
+			boolean isMod = false; // Used for the invalid texture check further down
 			if (identifier == null) {
 				// Identifiers ending in / are always invalid, but tryParse logs an error when attempting to parse.
+				// Just force the identifier to null here instead.
 				identifier = entity.getSprite().endsWith("/") ? null : Identifier.tryParse(entity.getSprite());
 				if (identifier == null) {
 					identifier = Glowcase.id("textures/sprite/invalid.png");
-				} else if (identifier.getNamespace().equals("mod")) {
+				} else if (identifier.getNamespace().equals("mod")) { // Special mod namespace uses mod icon.
 					String modId = identifier.getPath();
 					if (!modIconCache.containsKey(modId)) {
-						modIconCache.put(modId, Identifier.of(Glowcase.MODID, modId + "_icon"));
+						// Attempt to register mod icon and put it into the cache. Invalid icons will fall to
+						// the else branch and use the invalid icon.
 						Optional<ModContainer> mod = FabricLoader.getInstance().getModContainer(modId)
 							.or(() -> FabricLoader.getInstance().getModContainer(modId.replace("_", "-")))
 							.or(() -> FabricLoader.getInstance().getModContainer(modId.replace("_", "")));
 						NativeImageBackedTexture icon = mod.map(modContainer -> ModMetaUtil.getIcon(modContainer, 64 * client.options.getGuiScale().getValue())).orElse(null);
 						if (icon != null) {
+							// Needs to end in .png for the missing texture check further below.
+							modIconCache.put(modId, Identifier.of(Glowcase.MODID, modId + "_icon.png"));
 							client.getTextureManager().registerTexture(modIconCache.get(modId), icon);
+							identifier = modIconCache.get(modId);
+						} else {
+							identifier = Glowcase.id("textures/sprite/invalid.png");
 						}
+					} else {
+						// Mod is in the cache, just grab the identifier for it.
+						identifier = modIconCache.get(modId);
+						isMod = true;
 					}
-					identifier = modIconCache.get(modId);
 				}
 			}
 			TextureManager textureManager = client.getTextureManager();
 			ResourceManager resourceManager = ((TextureManagerAccessor) textureManager).glowcase$getResourceManager();
-			// TODO: Non-image resources, invalid mod IDs, and invalid items in the glowcase namespace show vanilla's
-			// TODO: missing texture icon rather than Glowcase's.
-			if (resourceManager.getResource(identifier).isEmpty() && !identifier.getNamespace().equals("glowcase")) {
+			if (resourceManager.getResource(identifier).isEmpty() && !isMod || !identifier.getPath().endsWith(".png")) {
 				/*
 				If the texture (file) does not exist, just replace it.
 				This happens a lot when editing a sprite block, so I'm adding it to avoid log spam

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
@@ -3,7 +3,10 @@ package dev.hephaestus.glowcase.client.render.block.entity;
 import dev.hephaestus.glowcase.Glowcase;
 import dev.hephaestus.glowcase.block.entity.SpriteBlockEntity;
 import dev.hephaestus.glowcase.client.util.BlockEntityRenderUtil;
+import dev.hephaestus.glowcase.client.util.ModMetaUtil;
 import dev.hephaestus.glowcase.mixin.client.TextureManagerAccessor;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.OverlayTexture;
@@ -13,6 +16,7 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.texture.NativeImageBackedTexture;
 import net.minecraft.client.texture.TextureManager;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.resource.ResourceManager;
@@ -21,8 +25,13 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.RotationAxis;
 import org.joml.Vector3f;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
 public record SpriteBlockEntityRenderer(BlockEntityRendererFactory.Context context) implements BlockEntityRenderer<SpriteBlockEntity> {
 	public static Identifier ITEM_TEXTURE = Glowcase.id("textures/item/sprite_block.png");
+	private static final Map<String, Identifier> modIconCache = new ConcurrentHashMap<>();
 
 	private static final Vector3f[] vertices = new Vector3f[] {
 		new Vector3f(-0.5F, -0.5F, 0.0F),
@@ -46,28 +55,44 @@ public record SpriteBlockEntityRenderer(BlockEntityRendererFactory.Context conte
 
 		matrices.scale(entity.scale, entity.scale, entity.scale);
 
+		MinecraftClient client = MinecraftClient.getInstance();
 		var entry = matrices.peek();
 		if (entity.getRenderItem() != null) {
-			MinecraftClient.getInstance().getItemRenderer().renderItem(entity.getRenderItem(),
+			client.getItemRenderer().renderItem(entity.getRenderItem(),
 				ModelTransformationMode.FIXED, light, overlay, matrices, vertexConsumers, entity.getWorld(), 0);
 		} else {
 			Identifier identifier = Identifier.tryParse(Glowcase.MODID, "textures/sprite/" + entity.getSprite() + ".png");
 			if (identifier == null) {
-				identifier = Identifier.tryParse(entity.getSprite());
+				// Identifiers ending in / are always invalid, but tryParse logs an error when attempting to parse.
+				identifier = entity.getSprite().endsWith("/") ? null : Identifier.tryParse(entity.getSprite());
 				if (identifier == null) {
 					identifier = Glowcase.id("textures/sprite/invalid.png");
+				} else if (identifier.getNamespace().equals("mod")) {
+					String modId = identifier.getPath();
+					if (!modIconCache.containsKey(modId)) {
+						modIconCache.put(modId, Identifier.of(Glowcase.MODID, modId + "_icon"));
+						Optional<ModContainer> mod = FabricLoader.getInstance().getModContainer(modId)
+							.or(() -> FabricLoader.getInstance().getModContainer(modId.replace("_", "-")))
+							.or(() -> FabricLoader.getInstance().getModContainer(modId.replace("_", "")));
+						NativeImageBackedTexture icon = mod.map(modContainer -> ModMetaUtil.getIcon(modContainer, 64 * client.options.getGuiScale().getValue())).orElse(null);
+						if (icon != null) {
+							client.getTextureManager().registerTexture(modIconCache.get(modId), icon);
+						}
+					}
+					identifier = modIconCache.get(modId);
 				}
-			} else {
-				TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
-				ResourceManager resourceManager = ((TextureManagerAccessor) textureManager).glowcase$getResourceManager();
-				if (resourceManager.getResource(identifier).isEmpty()) {
+			}
+			TextureManager textureManager = client.getTextureManager();
+			ResourceManager resourceManager = ((TextureManagerAccessor) textureManager).glowcase$getResourceManager();
+			// TODO: Non-image resources, invalid mod IDs, and invalid items in the glowcase namespace show vanilla's
+			// TODO: missing texture icon rather than Glowcase's.
+			if (resourceManager.getResource(identifier).isEmpty() && !identifier.getNamespace().equals("glowcase")) {
 				/*
 				If the texture (file) does not exist, just replace it.
 				This happens a lot when editing a sprite block, so I'm adding it to avoid log spam
 				- SkyNotTheLimit
 				 */
-					identifier = Glowcase.id("textures/sprite/invalid.png");
-				}
+				identifier = Glowcase.id("textures/sprite/invalid.png");
 			}
 			var vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(identifier));
 

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/SpriteBlockEntityRenderer.java
@@ -53,7 +53,10 @@ public record SpriteBlockEntityRenderer(BlockEntityRendererFactory.Context conte
 		} else {
 			Identifier identifier = Identifier.tryParse(Glowcase.MODID, "textures/sprite/" + entity.getSprite() + ".png");
 			if (identifier == null) {
-				identifier = Glowcase.id("textures/sprite/invalid.png");
+				identifier = Identifier.tryParse(entity.getSprite());
+				if (identifier == null) {
+					identifier = Glowcase.id("textures/sprite/invalid.png");
+				}
 			} else {
 				TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
 				ResourceManager resourceManager = ((TextureManagerAccessor) textureManager).glowcase$getResourceManager();

--- a/src/main/java/dev/hephaestus/glowcase/client/util/ModMetaUtil.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/util/ModMetaUtil.java
@@ -1,0 +1,72 @@
+package dev.hephaestus.glowcase.client.util;
+
+import dev.hephaestus.glowcase.Glowcase;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.minecraft.client.texture.NativeImage;
+import net.minecraft.client.texture.NativeImageBackedTexture;
+import org.apache.commons.lang3.Validate;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Liberally stolen from ballotbox, which literally stole it from ModMenu. Thanks ModMenu!
+ */
+public class ModMetaUtil {
+	private static final Map<Path, NativeImageBackedTexture> modIconCache = new HashMap<>();
+
+	public static NativeImageBackedTexture createIcon(ModContainer iconSource, String iconPath) {
+		try {
+			Path path = iconSource.getPath(iconPath);
+			NativeImageBackedTexture cachedIcon = modIconCache.get(path);
+			if (cachedIcon != null) {
+				return cachedIcon;
+			}
+			cachedIcon = modIconCache.get(path);
+			if (cachedIcon != null) {
+				return cachedIcon;
+			}
+			try (InputStream inputStream = Files.newInputStream(path)) {
+				NativeImage image = NativeImage.read(Objects.requireNonNull(inputStream));
+				Validate.validState(image.getHeight() == image.getWidth(), "Must be square icon");
+				NativeImageBackedTexture tex = new NativeImageBackedTexture(image);
+				modIconCache.put(path, tex);
+				return tex;
+			}
+
+		} catch (IllegalStateException e) {
+			if (e.getMessage().equals("Must be square icon")) {
+				Glowcase.LOGGER.error("Mod icon must be a square for icon source {}: {}",
+					iconSource.getMetadata().getId(),
+					iconPath,
+					e
+				);
+			}
+
+			return null;
+		} catch (Throwable t) {
+			if (!iconPath.equals("assets/" + iconSource.getMetadata().getId() + "/icon.png")) {
+				Glowcase.LOGGER.error("Invalid mod icon for icon source {}: {}", iconSource.getMetadata().getId(), iconPath, t);
+			}
+			return null;
+		}
+	}
+
+	public static NativeImageBackedTexture getIcon(ModContainer mod, int preferredSize) {
+		ModMetadata meta = mod.getMetadata();
+		String modId = meta.getId();
+		String iconPath = meta.getIconPath(preferredSize).orElse("assets/" + modId + "/icon.png");
+		final String finalIconSourceId = modId;
+		ModContainer iconSource = FabricLoader.getInstance()
+			.getModContainer(modId)
+			.orElseThrow(() -> new RuntimeException("Cannot get ModContainer for Fabric mod with id " + finalIconSourceId));
+		NativeImageBackedTexture icon = createIcon(iconSource, iconPath);
+		return icon;
+	}
+}

--- a/src/main/resources/assets/glowcase/lang/en_us.json
+++ b/src/main/resources/assets/glowcase/lang/en_us.json
@@ -75,6 +75,7 @@
 	"gui.glowcase.screen.hint.902": "Make sure you have an internet connection.",
 	"gui.glowcase.screen.hint.903": "Image format is not supported.",
 	"gui.glowcase.screen.eink": "Use E-Ink technology",
+	"gui.glowcase.screen.sprite_edit.sprite": "The first text box is the sprite to display on this block. Can be one of the following options:\n\n- The name of a built-in sprite, such as 'arrow'.\n- The ID of an item, such as 'minecraft:iron_sword'.\n- The namespaced path to a texture, such as 'minecraft:textures/item/iron_sword.png'.\n- A mod's icon, by using the mod ID in the special 'mod' namespace, such as 'mod:glowcase'.",
 	"gui.glowcase.screen.stretch": "Stretch image to fill the screen",
 	"gui.glowcase.updated_linked_screen": "Screen Tablet now linked to Screen at [%s].",
 	"gui.glowcase.linking_denied": "No permission to link to a screen.",

--- a/src/main/resources/assets/glowcase/lang/en_us.json
+++ b/src/main/resources/assets/glowcase/lang/en_us.json
@@ -75,7 +75,7 @@
 	"gui.glowcase.screen.hint.902": "Make sure you have an internet connection.",
 	"gui.glowcase.screen.hint.903": "Image format is not supported.",
 	"gui.glowcase.screen.eink": "Use E-Ink technology",
-	"gui.glowcase.screen.sprite_edit.sprite": "The first text box is the sprite to display on this block. Can be one of the following options:\n\n- The name of a built-in sprite, such as 'arrow'.\n- The ID of an item, such as 'minecraft:iron_sword'.\n- The namespaced path to a texture, such as 'minecraft:textures/item/iron_sword.png'.\n- A mod's icon, by using the mod ID in the special 'mod' namespace, such as 'mod:glowcase'.",
+	"gui.glowcase.screen.sprite_edit.sprite": "Can be one of the following options:\n\n- The name of a built-in sprite, such as 'arrow'.\n- The ID of an item, such as 'minecraft:iron_sword'.\n- The namespaced path to a texture, such as 'minecraft:textures/item/iron_sword.png'.\n- A mod's icon, by using the mod ID in the special 'mod' namespace, such as 'mod:glowcase'.",
 	"gui.glowcase.screen.stretch": "Stretch image to fill the screen",
 	"gui.glowcase.updated_linked_screen": "Screen Tablet now linked to Screen at [%s].",
 	"gui.glowcase.linking_denied": "No permission to link to a screen.",


### PR DESCRIPTION
This PR adds support to the sprite block for arbitrary textures and for mod icons, as described in the linked issue. One can quickly test this functionality using the sprites `minecraft:textures/item/iron_sword.png` and `mod:glowcase`, respectively.

This PR also adds a text tooltip to the sprite block edit screen, explaining all available options for the sprite block and how to use each one. The tooltip is rendera as it is, rather than on hover, since at high GUI scales, the tooltip would go off-screen. If this tooltip isn't wanted, please feel free to reset my branch to the previous commit before merging.

Please let me know if this PR can or should be improved in any way!

Closes #78 