### PR TITLE
Fix Item Mirroring in Item Provider but Add Option and Keep Default

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/ItemProviderBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/ItemProviderBlockEntity.java
@@ -9,6 +9,8 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +21,7 @@ public class ItemProviderBlockEntity extends GlowcaseBlockEntity implements Infi
 	protected ItemStack stack = ItemStack.EMPTY;
 	protected GivesItem givesItem = GivesItem.ALWAYS;
 	public long cooldown = 0;
+	public boolean mirrorItem = false;
 	protected final Map<UUID, Long> givenTimes = new HashMap<>();
 
 	public ItemProviderBlockEntity(BlockPos pos, BlockState state) {
@@ -66,6 +69,7 @@ public class ItemProviderBlockEntity extends GlowcaseBlockEntity implements Infi
 		NbtCompound timesNbt = new NbtCompound();
 		givenTimes.forEach((id, tick) -> timesNbt.putLong(id.toString(), tick));
 		tag.put("given_times", timesNbt);
+		tag.putBoolean("mirror_item", mirrorItem);
 	}
 
 	@Override
@@ -84,6 +88,8 @@ public class ItemProviderBlockEntity extends GlowcaseBlockEntity implements Infi
 		for (String key : given.getKeys()) {
 			givenTimes.put(UUID.fromString(key), given.getLong(key));
 		}
+		// true by default for compatibility with pre-existing BC25 builds
+		this.mirrorItem = tag.contains("mirror_item",  NbtElement.BYTE_TYPE) ? tag.getBoolean("mirror_item") : true;
 	}
 
 	public void cycleGiveType() {

--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/ItemProviderBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/ItemProviderBlockEditScreen.java
@@ -11,6 +11,7 @@ import net.minecraft.text.Text;
 public class ItemProviderBlockEditScreen extends GlowcaseScreen {
 
 	private final ItemProviderBlockEntity providerBlock;
+	private ButtonWidget mirrorItemWidget;
 	private ButtonWidget givesItemButton;
 	private TextFieldWidget cooldownWidget;
 	private TextWidget secondsLabel;
@@ -23,6 +24,11 @@ public class ItemProviderBlockEditScreen extends GlowcaseScreen {
 		super.init();
 
 		if (this.client != null) {
+			this.mirrorItemWidget = ButtonWidget.builder(getMirrorItemText(), (action) -> {
+				this.providerBlock.mirrorItem = !this.providerBlock.mirrorItem;
+				this.providerBlock.markDirty();
+				this.mirrorItemWidget.setMessage(getMirrorItemText());
+			}).dimensions(width / 2 - 75, height / 2 - 50, 150, 20).build();
 			this.givesItemButton = ButtonWidget.builder(Text.stringifiedTranslatable("gui.glowcase.gives_item", this.providerBlock.getGivesItem()), (action) -> {
 				this.providerBlock.cycleGiveType();
 				this.givesItemButton.setMessage(Text.stringifiedTranslatable("gui.glowcase.gives_item", this.providerBlock.getGivesItem()));
@@ -40,6 +46,7 @@ public class ItemProviderBlockEditScreen extends GlowcaseScreen {
 			this.secondsLabel = new TextWidget(width / 2 + 30, height / 2 + 5, 10, 20, Text.of("s"), this.textRenderer);
 			this.secondsLabel.visible = this.providerBlock.getGivesItem() == ItemProviderBlockEntity.GivesItem.TIMED;
 
+			this.addDrawableChild(this.mirrorItemWidget);
 			this.addDrawableChild(this.givesItemButton);
 			this.addDrawableChild(this.cooldownWidget);
 			this.addDrawableChild(this.secondsLabel);
@@ -56,5 +63,10 @@ public class ItemProviderBlockEditScreen extends GlowcaseScreen {
 
 		C2SEditItemProviderBlock.of(providerBlock).send();
 		super.close();
+	}
+
+	private Text getMirrorItemText() {
+		return Text.stringifiedTranslatable("gui.glowcase.mirror_item",
+			this.providerBlock.mirrorItem ? Text.stringifiedTranslatable("gui.yes") : Text.stringifiedTranslatable("gui.no"));
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/ItemProviderBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/ItemProviderBlockEntityRenderer.java
@@ -77,7 +77,12 @@ public record ItemProviderBlockEntityRenderer(BlockEntityRendererFactory.Context
 		matrices.translate(0, 0.5, 0);
 		matrices.scale(0.5F, 0.5F, 0.5F);
 		matrices.multiply(RotationAxis.POSITIVE_X.rotation(pitch));
+		matrices.push();
+		if (!entity.mirrorItem && facing.getAxis() != Direction.Axis.Y) {
+			matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
+		}
 		context.getItemRenderer().renderItem(entity.getStack(), ModelTransformationMode.FIXED, light, OverlayTexture.DEFAULT_UV, matrices, vertexConsumers, entity.getWorld(), 0);
+		matrices.pop();
 
 		HitResult hitResult = MinecraftClient.getInstance().crosshairTarget;
 		if (hitResult instanceof BlockHitResult && ((BlockHitResult) hitResult).getBlockPos().equals(entity.getPos())) {

--- a/src/main/java/dev/hephaestus/glowcase/packet/C2SEditItemProviderBlock.java
+++ b/src/main/java/dev/hephaestus/glowcase/packet/C2SEditItemProviderBlock.java
@@ -10,17 +10,18 @@ import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 
-public record C2SEditItemProviderBlock(BlockPos pos, ItemProviderBlockEntity.GivesItem givesItem, long cooldown) implements C2SEditBlockEntity {
+public record C2SEditItemProviderBlock(BlockPos pos, ItemProviderBlockEntity.GivesItem givesItem, long cooldown, boolean mirrorItem) implements C2SEditBlockEntity {
 	public static final CustomPayload.Id<C2SEditItemProviderBlock> ID = new CustomPayload.Id<>(Glowcase.id("channel.item_provider"));
 	public static final PacketCodec<RegistryByteBuf, C2SEditItemProviderBlock> PACKET_CODEC = PacketCodec.tuple(
 		BlockPos.PACKET_CODEC, C2SEditItemProviderBlock::pos,
 		PacketCodecs.BYTE.xmap(index -> ItemProviderBlockEntity.GivesItem.values()[index], givesItem -> (byte) givesItem.ordinal()), C2SEditItemProviderBlock::givesItem,
 		PacketCodecs.VAR_LONG, C2SEditItemProviderBlock::cooldown,
+		PacketCodecs.BOOL, C2SEditItemProviderBlock::mirrorItem,
 		C2SEditItemProviderBlock::new
 	);
 
 	public static C2SEditItemProviderBlock of(ItemProviderBlockEntity be) {
-		return new C2SEditItemProviderBlock(be.getPos(), be.getGivesItem(), be.cooldown);
+		return new C2SEditItemProviderBlock(be.getPos(), be.getGivesItem(), be.cooldown, be.mirrorItem);
 	}
 
 	@Override
@@ -33,5 +34,6 @@ public record C2SEditItemProviderBlock(BlockPos pos, ItemProviderBlockEntity.Giv
 		if (!(blockEntity instanceof ItemProviderBlockEntity be)) return;
 		be.setGivesItem(this.givesItem());
 		be.cooldown = this.cooldown;
+		be.mirrorItem = this.mirrorItem;
 	}
 }

--- a/src/main/resources/assets/glowcase/lang/en_us.json
+++ b/src/main/resources/assets/glowcase/lang/en_us.json
@@ -23,6 +23,7 @@
 	"gui.glowcase.pitch_value": "Pitch: %d",
 	"gui.glowcase.yaw_value": "Yaw: %d",
 	"gui.glowcase.alignment": "Alignment: %s",
+	"gui.glowcase.mirror_item": "Mirror Item: %s",
 	"gui.glowcase.gives_item": "Gives Item: %s",
 	"gui.glowcase.shadow_type": "Shadow Type: %s",
 	"gui.glowcase.rotation_type": "Rotation Type: %s",


### PR DESCRIPTION
Fixes item providers placed on walls having the item mirrored, while also:

- Ensuring pre-existing item providers are kept as-is.
- Added an option to the item provider's edit screen to mirror the item if wanted.