### PR TITLE
chore: Improve EMI block performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ authors=HavenKing, ModFest
 contributors=Chai, Sisby folk, Sammy.K, ShiroJR, Superkat32, maximumpower55, CallMeEcho, quaternary, comp500, LemmaEOF, acikek, TheEpicBlock, SkyNotTheLimit, Patbox, AmyMialee, Emi
 license=CC0-1.0
 # Mod Version
-baseVersion=2.0.0
+baseVersion=2.0.1
 # Branch Metadata
 branch=1.21
 tagBranch=1.21

--- a/src/main/java/dev/hephaestus/glowcase/util/EmiClientUtils.java
+++ b/src/main/java/dev/hephaestus/glowcase/util/EmiClientUtils.java
@@ -14,63 +14,75 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.gl.SimpleFramebuffer;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.BufferBuilderStorage;
-import net.minecraft.client.render.BufferRenderer;
-import net.minecraft.client.render.DiffuseLighting;
-import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.Tessellator;
-import net.minecraft.client.render.VertexFormat;
-import net.minecraft.client.render.VertexFormats;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fStack;
+import org.joml.Vector2i;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public class EmiClientUtils {
 	private static final BufferBuilderStorage SORRY = new BufferBuilderStorage(1);
-	private static final ConcurrentMap<String, CachedBuffer> FB_CACHE = new ConcurrentHashMap<>();
+	private static final Map<Vector2i, CachedBuffer> BACKGROUND_CACHE = new ConcurrentHashMap<>();
+	private static final Map<EmiRecipe, CachedBuffer> FRAMEBUFFER_CACHE = new ConcurrentHashMap<>();
+
+	private static final Map<EmiRecipe, GlowcaseWidgetHolder> HOLDER_CACHE = new ConcurrentHashMap<>();
+	private static final Map<Identifier, EmiRecipe> RECIPE_CACHE = new ConcurrentHashMap<>();
+	private static final boolean GET_ERROR = MinecraftClient.IS_SYSTEM_MAC;
 
 	// a container to hold the buffer
 	private static class CachedBuffer {
-        public final Framebuffer fb;
-        public volatile boolean dirty;
+        public final Framebuffer framebuffer;
+        private volatile boolean dirty;
+		public volatile long expire = System.currentTimeMillis() + 33;
 
-        public CachedBuffer(Framebuffer fb, boolean dirty) {
-            this.fb = fb;
+        public CachedBuffer(Framebuffer framebuffer, boolean dirty) {
+            this.framebuffer = framebuffer;
             this.dirty = dirty;
         }
-    }
+
+		public boolean isDirty() {
+			return dirty || System.currentTimeMillis() >= expire;
+		}
+
+		public void setDirty(boolean dirty) {
+			this.dirty = dirty;
+
+			if (!dirty) {
+				expire = System.currentTimeMillis() + 33;
+			}
+		}
+	}
 
 	public static void disposeCache() {
-        for (CachedBuffer cached : FB_CACHE.values()) {
+        for (CachedBuffer cached : FRAMEBUFFER_CACHE.values()) {
             try {
-                cached.fb.delete();
+                cached.framebuffer.delete();
             } catch (Exception e) {
                 Glowcase.LOGGER.error("Error disposing: " + e.getMessage());
             }
         }
 
-        FB_CACHE.clear();
+        FRAMEBUFFER_CACHE.clear();
     }
 
 	public static void markAllDirty() {
-        for (CachedBuffer cached : FB_CACHE.values()) {
-            cached.dirty = true;
+        for (CachedBuffer cached : FRAMEBUFFER_CACHE.values()) {
+            cached.setDirty(true);
         }
     }
 
-	public static void displayRecipe(Identifier rid) {
-		if (rid == null) {
+	public static void displayRecipe(Identifier recipeId) {
+		if (recipeId == null) {
 			return;
 		}
-		EmiRecipe recipe = EmiApi.getRecipeManager().getRecipe(rid);
+		EmiRecipe recipe = EmiApi.getRecipeManager().getRecipe(recipeId);
 		if (recipe == null) {
 			return;
 		}
@@ -78,6 +90,7 @@ public class EmiClientUtils {
 	}
 
 	public static boolean renderRecipe(MatrixStack matrices, String recipeString, BlockPos pos) {
+		MinecraftClient client = MinecraftClient.getInstance();
 		EmiRecipe recipe = getRecipeToDisplay(recipeString, pos);
 		if (recipe == null) {
 			return false;
@@ -85,31 +98,18 @@ public class EmiClientUtils {
 
 		int fullWidth = recipe.getDisplayWidth() + 8;
 		int fullHeight = recipe.getDisplayHeight() + 8;
-		Framebuffer fb = createFramebuffer(recipe);
 
         try {
-            fb.beginRead();
-            RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-            RenderSystem.setShaderTexture(0, fb.getColorAttachment());
-            RenderSystem.enableDepthTest();
+			// getEffectVertexConsumers doesn't cause random rendering issues like getEntityVertexConsumers
+			DrawContext context = new DrawContext(client, SORRY.getEffectVertexConsumers());
 
-            Tessellator tess = Tessellator.getInstance();
-            BufferBuilder builder = tess.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-            MatrixStack.Entry entry = matrices.peek();
-            float xMin = -0.15f / 16 * fullWidth;
-            float xMax =  0.15f / 16 * fullWidth;
-            float yMin = -0.15f / 16 * fullHeight;
-            float yMax =  0.15f / 16 * fullHeight;
+			Framebuffer background = createBackground(recipe, context);
+			renderFramebuffer(background, matrices, fullWidth, fullHeight);
 
-            builder.vertex(entry, xMin, yMax, 0).color(255, 255, 255, 255).texture(1, 1);
-            builder.vertex(entry, xMax, yMax, 0).color(255, 255, 255, 255).texture(0, 1);
-            builder.vertex(entry, xMax, yMin, 0).color(255, 255, 255, 255).texture(0, 0);
-            builder.vertex(entry, xMin, yMin, 0).color(255, 255, 255, 255).texture(1, 0);
-
-            BufferRenderer.drawWithGlobalProgram(builder.end());
+			Framebuffer foreground = createFramebuffer(recipe, context);
+			renderFramebuffer(foreground, matrices, fullWidth, fullHeight);
         } catch (Exception e) {
-            Glowcase.LOGGER.error("Error rendering framebuffer: " + e.getMessage());
-            e.printStackTrace();
+            Glowcase.LOGGER.error("Error rendering framebuffer!", e);
         } finally {
             MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
         }
@@ -119,8 +119,17 @@ public class EmiClientUtils {
 
 	public static EmiRecipe getRecipeToDisplay(String recipeString, BlockPos pos) {
 		Identifier rid = Identifier.tryParse(recipeString);
+
+		if (rid != null) {
+			EmiRecipe recipe = RECIPE_CACHE.computeIfAbsent(rid, identifier -> EmiApi.getRecipeManager().getRecipe(rid));
+
+			if (recipe != null) return recipe;
+		}
+
 		EmiRecipe recipe;
-		if ((rid == null || EmiApi.getRecipeManager().getRecipe(rid) == null) && recipeString.startsWith("xyzzy")) {
+
+		// TODO: Improve; Replace with list field entry instead of single string
+		if (recipeString.startsWith("xyzzy")) {
 			String[] parts = recipeString.split(" ");
 			List<EmiRecipe> recipes = EmiApi.getRecipeManager().getRecipes();
 			if (parts.length == 2) {
@@ -137,39 +146,104 @@ public class EmiClientUtils {
 			}
 			recipe = recipes.get(new Random(c).nextInt(recipes.size()));
 		} else {
-			if (rid == null) {
-				return null;
-			}
-			recipe = EmiApi.getRecipeManager().getRecipe(rid);
+			return null;
 		}
+
 		return recipe;
 	}
 
-	private static Framebuffer createFramebuffer(EmiRecipe recipe) {
+	private static void renderFramebuffer(Framebuffer framebuffer, MatrixStack matrixStack, int fullWidth, int fullHeight) {
+		framebuffer.beginRead();
+
+		RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+		RenderSystem.setShaderTexture(0, framebuffer.getColorAttachment());
+		RenderSystem.enableDepthTest();
+
+		Tessellator tess = Tessellator.getInstance();
+		BufferBuilder builder = tess.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+		MatrixStack.Entry entry = matrixStack.peek();
+		float xMin = -0.15f / 16 * fullWidth;
+		float xMax = 0.15f / 16 * fullWidth;
+		float yMin = -0.15f / 16 * fullHeight;
+		float yMax = 0.15f / 16 * fullHeight;
+
+		builder.vertex(entry, xMin, yMax, 0).color(255, 255, 255, 255).texture(1, 1);
+		builder.vertex(entry, xMax, yMax, 0).color(255, 255, 255, 255).texture(0, 1);
+		builder.vertex(entry, xMax, yMin, 0).color(255, 255, 255, 255).texture(0, 0);
+		builder.vertex(entry, xMin, yMin, 0).color(255, 255, 255, 255).texture(1, 0);
+
+		BufferRenderer.drawWithGlobalProgram(builder.end());
+
+		framebuffer.endRead();
+	}
+
+	private static Framebuffer createBackground(EmiRecipe recipe, DrawContext context) {
+		int width = recipe.getDisplayWidth() + 8;
+		int height = recipe.getDisplayHeight() + 8;
+
+		return BACKGROUND_CACHE.computeIfAbsent(new Vector2i(recipe.getDisplayWidth(), recipe.getDisplayHeight()), ignored -> {
+			SimpleFramebuffer framebuffer = new SimpleFramebuffer(width, height, true, GET_ERROR);
+
+			Matrix4fStack view = RenderSystem.getModelViewStack();
+			view.pushMatrix();
+			view.identity();
+			view.scale(2f / width, -2f / height, -1f / 1000f);
+			view.translate(-width / 2f, -height / 2f, 0.0f);
+			view.translate(0.0f, 0.0f, 10.0f);
+			RenderSystem.applyModelViewMatrix();
+
+			float originalFogEnd = RenderSystem.getShaderFogEnd();
+			RenderSystem.setShaderFogEnd(Float.MAX_VALUE);
+
+			Matrix4f backupProj = RenderSystem.getProjectionMatrix();
+			RenderSystem.setProjectionMatrix(new Matrix4f().identity(), VertexSorter.BY_Z);
+
+			RecipeBackground background = new RecipeBackground(0, 0, width, height);
+			framebuffer.beginWrite(true);
+
+			background.render(context, -9999, -9999, 0);
+
+			// Magic incantation/desperate prayer
+			RenderSystem.enableDepthTest();
+			RenderSystem.disableBlend();
+			RenderSystem.enableCull();
+			RenderSystem.setShaderColor(1, 1, 1, 1);
+			DiffuseLighting.enableForLevel();
+
+			RenderSystem.setProjectionMatrix(backupProj, VertexSorter.BY_DISTANCE);
+			view.popMatrix();
+			RenderSystem.applyModelViewMatrix();
+			SORRY.getEntityVertexConsumers().draw();
+
+			framebuffer.endWrite();
+			RenderSystem.setShaderFogEnd(originalFogEnd);
+
+			return new CachedBuffer(framebuffer, false);
+		}).framebuffer;
+	}
+
+	private static Framebuffer createFramebuffer(EmiRecipe recipe, DrawContext context) {
 		MinecraftClient client = MinecraftClient.getInstance();
 
 		int width = recipe.getDisplayWidth() + 8;
 		int height = recipe.getDisplayHeight() + 8;
 		int scale = 4;
 
-		String recipeId = recipe.getId() != null ? recipe.getId().toString() : "unknown";
-		String key = recipeId + "_" + (width * scale) + "x" + (height * scale);
-
-		CachedBuffer cached = FB_CACHE.get(key);
+		CachedBuffer cached = FRAMEBUFFER_CACHE.get(recipe);
         if (cached == null) {
             Framebuffer fb = new SimpleFramebuffer(width * scale, height * scale, true, MinecraftClient.IS_SYSTEM_MAC);
             fb.setClearColor(0f, 0f, 0f, 0f);
 
             cached = new CachedBuffer(fb, true);
-            FB_CACHE.put(key, cached);
+            FRAMEBUFFER_CACHE.put(recipe, cached);
         }
 
 		// rerender every frame so dont
-		// if (!cached.dirty) {
-        //     return cached.fb;
-        // }
+		 if (!cached.isDirty()) {
+             return cached.framebuffer;
+         }
 
-		Framebuffer framebuffer = cached.fb;
+		Framebuffer framebuffer = cached.framebuffer;
 
 		try {
 			framebuffer.clear(MinecraftClient.IS_SYSTEM_MAC);
@@ -188,21 +262,32 @@ public class EmiClientUtils {
 
 			Matrix4f backupProj = RenderSystem.getProjectionMatrix();
 			RenderSystem.setProjectionMatrix(new Matrix4f().identity(), VertexSorter.BY_Z);
-			GlowcaseWidgetHolder holder = new GlowcaseWidgetHolder(recipe.getDisplayWidth(), recipe.getDisplayHeight());
-			holder.widgets.add(new RecipeBackground(-4, -4, recipe.getDisplayWidth() + 8, recipe.getDisplayHeight() + 8));
-			recipe.addWidgets(holder);
-			// getEffectVertexConsumers doesn't cause random rendering issues like getEntityVertexConsumers
-			DrawContext context = new DrawContext(client, SORRY.getEntityVertexConsumers());
+
+			// Cache the holder so it doesn't create several new classes every frame, just for the sake of it
+			// TODO: Clear on EMI reload
+			GlowcaseWidgetHolder holder = HOLDER_CACHE.computeIfAbsent(recipe, emiRecipe -> {
+				GlowcaseWidgetHolder widgetHolder = new GlowcaseWidgetHolder(recipe.getDisplayWidth(), recipe.getDisplayHeight());
+				//widgetHolder.widgets.add(new RecipeBackground(-4, -4, recipe.getDisplayWidth() + 8, recipe.getDisplayHeight() + 8));
+				recipe.addWidgets(widgetHolder);
+				return widgetHolder;
+			});
+
 			context.getMatrices().translate(4, 4, 0);
+
+			//Widget widget = holder.widgets.get(Math.min(2, holder.widgets.size()));
+			//widget.render(context, -9999, -9999, 0);
+
 			for (Widget widget : holder.widgets) {
 				widget.render(context, -9999, -9999, 0);
 			}
+
 			// Magic incantation/desperate prayer
 			RenderSystem.enableDepthTest();
 			RenderSystem.disableBlend();
 			RenderSystem.enableCull();
 			RenderSystem.setShaderColor(1, 1, 1, 1);
-			DiffuseLighting.enableForLevel();
+			// Using disableForLevel fixes a severe light flicker issue
+			DiffuseLighting.disableForLevel();
 
 			RenderSystem.setProjectionMatrix(backupProj, VertexSorter.BY_DISTANCE);
 			view.popMatrix();
@@ -213,14 +298,13 @@ public class EmiClientUtils {
 			RenderSystem.setShaderFogEnd(originalFogEnd);
 			client.getFramebuffer().beginWrite(true);
 
-			cached.dirty = true;
-			// cached.dirty = false;
+			//cached.dirty = true;
+			 cached.setDirty(false);
 		} catch (Exception e) {
-			Glowcase.LOGGER.error("Error during framebuffer creation: " + e.getMessage());
-			e.printStackTrace();
+			Glowcase.LOGGER.error("Error during framebuffer creation!", e);
 
 			// if an error occurs during framebuffer creation, mark the cache as dirty to refresh
-			cached.dirty = true;
+			cached.setDirty(true);
 		}
 
 		return framebuffer;


### PR DESCRIPTION
This limits EMI recipes to 30 FPS, renders the background as separate, giving it it's own buffer as it is a nine slice, and there is no need to rebuild it every render of the recipe, and caches the widget holder to stop creating new classes every render.

It also implements a simple recipe cache, but that can be removed. Was a remainder of my testing

I would like to see tests and comparisons on other hardware too, as technically it causes lag spikes every 33ms