### PR TITLE
Fix item provider timing bug

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/ItemProviderBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/ItemProviderBlockEntity.java
@@ -123,7 +123,10 @@ public class ItemProviderBlockEntity extends GlowcaseBlockEntity implements Infi
 			itemStack.increment(getStack().getCount());
 			itemStack.capCount(itemStack.getMaxCount());
 			player.setStackInHand(Hand.MAIN_HAND, itemStack);
+		} else {
+			return;
 		}
+
 		if (!player.isCreative()) {
 			givenTimes.put(player.getUuid(), world.getTime());
 			markDirty();


### PR DESCRIPTION
Item providers would previously always set the timer, even if you didn't get the item.
This fixes that.