### PR TITLE
fix: should_render defaulting to false instead of true

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/ItemProviderBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/ItemProviderBlockEntity.java
@@ -91,7 +91,9 @@ public class ItemProviderBlockEntity extends GlowcaseBlockEntity implements Infi
 			givenTimes.put(UUID.fromString(key), given.getLong(key));
 		}
 
-		this.shouldRenderItem = tag.getBoolean("should_render");
+		if (tag.contains("should_render", NbtElement.NUMBER_TYPE)) {
+			this.shouldRenderItem = tag.getBoolean("should_render");
+		}
 	}
 
 	public void cycleGiveType() {


### PR DESCRIPTION
> [!IMPORTANT]
> All chunks 2.1.2-seen chunks need to be reloaded on 2.1.1 for this to revert already changed providers.
> Otherwise you will need to revert this manually via NBT editing tools.
> 
> Avoid using 2.1.0 and earlier to revert as #104 introduced a non-rollback safe format change to text blocks.