### PR TITLE
fix: Minor sound instance leak

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/SoundPlayerBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/SoundPlayerBlockEntity.java
@@ -223,7 +223,7 @@ public class SoundPlayerBlockEntity extends GlowcaseBlockEntity {
 
 		@Override
 		public void tick() {
-			if (this.soundBlock.nowPlaying != this) {
+			if (this.soundBlock.isRemoved() || this.soundBlock.nowPlaying != this) {
 				this.setDone();
 				return;
 			}


### PR DESCRIPTION
Only really affects when the sound block itself is removed. This won't affect regular game play.