### PR TITLE
fix: Check queue to respect sound block's delay

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/SoundPlayerBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/SoundPlayerBlockEntity.java
@@ -2,6 +2,7 @@ package dev.hephaestus.glowcase.block.entity;
 
 import com.mojang.logging.LogUtils;
 import dev.hephaestus.glowcase.Glowcase;
+import dev.hephaestus.glowcase.client.util.SoundPlayerProxy;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockState;
@@ -110,8 +111,8 @@ public class SoundPlayerBlockEntity extends GlowcaseBlockEntity {
 
 		final PositionedSoundLoop oldInstance = entity.nowPlaying;
 		if (oldInstance != null) {
-			if (oldInstance.isCompatible() && soundManager.isPlaying(oldInstance)) {
-				// no-op when already playing something
+			if (oldInstance.isCompatible() && ((SoundPlayerProxy) soundManager).glowcase$isQueuedOrPlaying(oldInstance)) {
+				// no-op when already playing something, or waiting to be played
 				return;
 			}
 

--- a/src/main/java/dev/hephaestus/glowcase/client/util/SoundPlayerProxy.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/util/SoundPlayerProxy.java
@@ -1,0 +1,32 @@
+package dev.hephaestus.glowcase.client.util;
+
+import net.minecraft.client.sound.SoundInstance;
+
+/**
+ * A peek into the sound system to query whether sounds are queued.
+ *
+ * @author Ampflower
+ * @see dev.hephaestus.glowcase.mixin.client.sound.SoundManagerMixin
+ * @see dev.hephaestus.glowcase.mixin.client.sound.SoundSystemMixin
+ **/
+public interface SoundPlayerProxy {
+	/**
+	 * Returns whether the sound instance is currently queued, but not playing.
+	 *
+	 * @param sound The sound instance to check for.
+	 * @return Whether the given sound instance is queued, but not playing.
+	 * @see #glowcase$isQueuedOrPlaying(SoundInstance)
+	 * @see net.minecraft.client.sound.SoundManager#isPlaying(SoundInstance)
+	 */
+	boolean glowcase$isQueued(SoundInstance sound);
+
+	/**
+	 * Returns whether the sound instance is currently queued or playing.
+	 *
+	 * @param sound The sound instance to check for.
+	 * @return Whether the given sound instance is queued or currently playing.
+	 * @see #glowcase$isQueued(SoundInstance)
+	 * @see net.minecraft.client.sound.SoundManager#isPlaying(SoundInstance)
+	 */
+	boolean glowcase$isQueuedOrPlaying(SoundInstance sound);
+}

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/sound/SoundManagerMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/sound/SoundManagerMixin.java
@@ -1,0 +1,31 @@
+package dev.hephaestus.glowcase.mixin.client.sound;
+
+import dev.hephaestus.glowcase.client.util.SoundPlayerProxy;
+import net.minecraft.client.sound.SoundInstance;
+import net.minecraft.client.sound.SoundManager;
+import net.minecraft.client.sound.SoundSystem;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+/**
+ * @author Ampflower
+ * @implNote Functions here generally need to proxy to the {@link SoundSystem sound system}.
+ * @see SoundSystemMixin
+ **/
+@Mixin(SoundManager.class)
+public class SoundManagerMixin implements SoundPlayerProxy {
+	@Shadow
+	@Final
+	private SoundSystem soundSystem;
+
+	@Override
+	public boolean glowcase$isQueued(final SoundInstance sound) {
+		return ((SoundPlayerProxy) this.soundSystem).glowcase$isQueued(sound);
+	}
+
+	@Override
+	public boolean glowcase$isQueuedOrPlaying(final SoundInstance sound) {
+		return ((SoundPlayerProxy) this.soundSystem).glowcase$isQueuedOrPlaying(sound);
+	}
+}

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/sound/SoundSystemMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/sound/SoundSystemMixin.java
@@ -1,0 +1,40 @@
+package dev.hephaestus.glowcase.mixin.client.sound;
+
+import dev.hephaestus.glowcase.client.util.SoundPlayerProxy;
+import net.minecraft.client.sound.SoundInstance;
+import net.minecraft.client.sound.SoundSystem;
+import net.minecraft.client.sound.TickableSoundInstance;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Ampflower
+ **/
+@Mixin(SoundSystem.class)
+public abstract class SoundSystemMixin implements SoundPlayerProxy {
+	@Shadow
+	public abstract boolean isPlaying(final SoundInstance sound);
+
+	@Shadow
+	@Final
+	private Map<SoundInstance, Integer> startTicks;
+
+	@Shadow
+	@Final
+	private List<TickableSoundInstance> soundsToPlayNextTick;
+
+	@Override
+	public boolean glowcase$isQueued(final SoundInstance sound) {
+		return this.startTicks.containsKey(sound) ||
+			this.soundsToPlayNextTick.contains(sound);
+	}
+
+	@Override
+	public boolean glowcase$isQueuedOrPlaying(final SoundInstance sound) {
+		return this.isPlaying(sound) || this.glowcase$isQueued(sound);
+	}
+}

--- a/src/main/resources/glowcase.mixins.json
+++ b/src/main/resources/glowcase.mixins.json
@@ -16,7 +16,9 @@
 		"client.RenderSystemAccessor",
 		"client.TextRendererAccessor",
 		"client.TextureManagerAccessor",
-		"client.compat.DynamicBufferShardCompatMixin"
+		"client.compat.DynamicBufferShardCompatMixin",
+		"client.sound.SoundManagerMixin",
+		"client.sound.SoundSystemMixin"
 	],
 	"server": [],
 	"injectors": {


### PR DESCRIPTION
isPlaying was evidently not sufficient for checking if the sound was also queued.

Caught in 1.21.7 but applies to 1.21 as well.

Had a bad check that didn't account for the sound engine's queued state. This should have a new release to not leave the last version for 1.21 with broken code.