### PR TITLE
fix: Make sure color picker widgets stay within the screen's bounds.

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/TextBlockEditScreen.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/gui/screen/ingame/TextBlockEditScreen.java
@@ -384,7 +384,7 @@ public class TextBlockEditScreen extends TextEditorScreen {
 	}
 
 	private void colorListenerClicked(TextFieldWidget textWidget) {
-		this.colorPickerWidget.setPosition(textWidget.getX(), textWidget.getY() + textWidget.getHeight());
+		this.colorPickerWidget.setPosition(Math.min(textWidget.getX(), width - colorPickerWidget.getWidth()), textWidget.getY() + textWidget.getHeight());
 		this.colorPickerWidget.setTargetElement(textWidget);
 		this.colorPickerWidget.setOnAccept(null);
 		this.colorPickerWidget.setOnCancel(picker -> {


### PR DESCRIPTION
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/ee9c47af-e28d-40c2-9bc6-271b83da5547" />

Made color picker widgets never overflow off the screen.

Fixes #124 