### PR TITLE
Entity Display Block entity models have no lighting 

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/EntityDisplayBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/EntityDisplayBlockEntity.java
@@ -55,7 +55,9 @@ public class EntityDisplayBlockEntity extends DisplayBlockEntity implements Stac
 
 	public static void tick(Level world, BlockPos blockPos, BlockState state, EntityDisplayBlockEntity blockEntity) {
 		if (blockEntity.displayEntity == null && blockEntity.entityType != null) {
-			blockEntity.setDisplayEntity(blockEntity.entityType.create(world, EntitySpawnReason.EVENT));
+			Entity displayEntity = blockEntity.entityType.create(world, EntitySpawnReason.EVENT);
+			displayEntity.snapTo(blockPos.getX(),blockPos.getY(),blockPos.getZ());
+			blockEntity.setDisplayEntity(displayEntity);
 		}
 //		if (blockEntity.getDisplayEntity() != null && blockEntity.getDisplayEntity().getType().is(TICK)) {
 			if (blockEntity.getDisplayEntity() != null && blockEntity.getDisplayEntity().getType().builtInRegistryHolder().is(TICK)) {


### PR DESCRIPTION
Fixed bug where entity models from entity display block have no lighting. 

<img width="1920" height="1017" alt="2026-04-04_18 17 54" src="https://github.com/user-attachments/assets/1a5b1477-eba9-4586-a564-7b1de50a8b0f" />
