### PR TITLE
Update sodium compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
 	localRuntime(libs.modmenu)
 
 	compileOnly(libs.sodium)
-	// localRuntime(libs.sodium)
+	localRuntime(libs.sodium)
 }
 
 loom {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -13,8 +13,8 @@ placeholder = "3.0.0-beta.2+26.1"
 #polydex = "1.8.1+1.21.11"
 # emi = "1.1.19+1.21.1"
 rrv = "8.1.1+26.1.2"
-modmenu = "18.0.0-alpha.6"
-sodium = "0.8.9+mc26.1.1"
+modmenu = "18.0.0"
+sodium = "0.9.1+mc26.1.2"
 
 [plugins]
 loom = { id = "net.fabricmc.fabric-loom", version.ref = "loom" }

--- a/src/main/java/dev/hephaestus/glowcase/client/sodium/BakedBESortingTask.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/sodium/BakedBESortingTask.java
@@ -37,7 +37,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 		super(section, time, absoluteCameraPos);
 		this.levelRenderer = GlowcaseLevelRenderer.getInstance();
 		this.sectionInfo = sectionInfo;
-		this.sectionNode = render.getPosition().asLong();
+		this.sectionNode = this.section.getPosition().asLong();
 	}
 
 	@Override
@@ -53,7 +53,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 		ByteBufferBuilder bufferBuilder = indexBufferPool.acquire();
 
 		int size = 0;
-		for (GlowcaseRenderSectionInfo.DrawEntry entry : sectionInfo) {
+		for (GlowcaseRenderSectionInfo.DrawEntry entry : this.sectionInfo) {
 			final var sorter = entry.sorter();
 			if (sorter == null) continue;
 
@@ -71,7 +71,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 					return null;
 				}
 
-				success = renderDispatcher.allocateIndexBuffers(sectionNode, entry.renderType(), indexBuffer.byteBuffer());
+				success = renderDispatcher.allocateIndexBuffers(this.sectionNode, entry.renderType(), indexBuffer.byteBuffer());
 
 				if (!success && !RenderSystem.isOnRenderThread()) {
 					Thread.onSpinWait();
@@ -82,7 +82,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 			indexBuffer.close();
 		}
 
-		sectionInfo.setTranslucencyPointOfView(absoluteCameraPos.get(new Vector3f()), sectionNode);
+		this.sectionInfo.setTranslucencyPointOfView(this.absoluteCameraPos.get(new Vector3f()), this.sectionNode);
 
 		// Only clear after. There is no need to do it every iteration, it has 4GiB of capacity.
 		// If this runs out, there is a much bigger problem to be solved.
@@ -90,15 +90,15 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 		indexBufferPool.release(bufferBuilder);
 		profiler.pop();
 
-		return new Output(render, submitTime, size);
+		return new Output(this.section, this.submitTime, size);
 	}
 
 	@Override
 	public long estimateTaskSizeWith(MeshTaskSizeEstimator estimator) {
-		if (isGone()) return 0;
+		if (this.isGone()) return 0;
 
 		int size = 0;
-		for (GlowcaseRenderSectionInfo.DrawEntry entry : sectionInfo) {
+		for (GlowcaseRenderSectionInfo.DrawEntry entry : this.sectionInfo) {
 			size += TranslucentData.quadCountToIndexBytes(entry.indexCount());
 		}
 
@@ -106,7 +106,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 	}
 
 	private boolean isGone() {
-		return !levelRenderer.visibleSections().isVisible(sectionNode);
+		return !this.levelRenderer.visibleSections().isVisible(this.sectionNode);
 	}
 
 	public static BakedBESortingTask create(RenderSection section, int frame, Vector3dc absoluteCameraPos) {
@@ -125,7 +125,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 
 		@Override
 		protected long calculateResultSize() {
-			return size;
+			return this.size;
 		}
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/client/sodium/BakedBESortingTask.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/sodium/BakedBESortingTask.java
@@ -44,7 +44,7 @@ public class BakedBESortingTask extends ChunkBuilderTask<BakedBESortingTask.Outp
 	public Output execute(ChunkBuildContext context, CancellationToken cancellationToken) {
 		if (cancellationToken.isCancelled() || isGone()) return null;
 
-		GlowcaseSectionRenderDispatcher renderDispatcher = levelRenderer.getSectionRenderDispatcher();
+		GlowcaseSectionRenderDispatcher renderDispatcher = this.levelRenderer.getSectionRenderDispatcher();
 		if (renderDispatcher == null) return null;
 
 		ProfilerFiller profiler = Profiler.get();

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/ChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/ChunkBuilderMeshingTaskMixin.java
@@ -136,14 +136,14 @@ public abstract class ChunkBuilderMeshingTaskMixin extends ChunkBuilderTask<Chun
 		}
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/data/BuiltSectionInfo$Builder;setOcclusionData(Lnet/minecraft/client/renderer/chunk/VisibilitySet;)V", shift = At.Shift.AFTER), method = "execute(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lnet/caffeinemc/mods/sodium/client/util/task/CancellationToken;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;")
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/data/BuiltSectionInfo$Builder;setOcclusionData([Lnet/minecraft/client/renderer/chunk/VisibilitySet;)V", shift = At.Shift.AFTER), method = "execute(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lnet/caffeinemc/mods/sodium/client/util/task/CancellationToken;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;")
 	private void queueCompilation(
 		CallbackInfoReturnable<SectionCompiler.Results> cir,
 		@Share("nodeStorage") LocalRef<SubmitNodeStorage> nodeStorageRef,
 		@Share("vertexSorting") LocalRef<VertexSorting> vertexSortingRef,
 		@Share("bakedMeshes") LocalRef<BakedMeshes> bakedMeshes
 	) {
-		bakedMeshes.set(GlowcaseLevelRenderer.getInstance().updateAndCompile(this.render.getPosition().asLong(), nodeStorageRef.get(), vertexSortingRef.get()));
+		bakedMeshes.set(GlowcaseLevelRenderer.getInstance().updateAndCompile(this.section.getPosition().asLong(), nodeStorageRef.get(), vertexSortingRef.get()));
 	}
 
 	@Expression("return null")
@@ -164,7 +164,7 @@ public abstract class ChunkBuilderMeshingTaskMixin extends ChunkBuilderTask<Chun
 	) {
 		GlowcaseLevelRenderer levelRenderer = GlowcaseLevelRenderer.getInstance();
 		BakedMeshes meshes = bakedMeshesRef.get();
-		long sectionNode = render.getPosition().asLong();
+		long sectionNode = this.section.getPosition().asLong();
 		if (meshes == null) {
 			levelRenderer.releaseSection(sectionNode);
 			return;

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/ChunkBuilderSortingTaskMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/ChunkBuilderSortingTaskMixin.java
@@ -1,8 +1,6 @@
 package dev.hephaestus.glowcase.mixin.client.bakedbe.sodium;
 
 import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.VertexSorting;
@@ -32,17 +30,16 @@ public abstract class ChunkBuilderSortingTaskMixin extends ChunkBuilderTask<Chun
 		super(render, time, absoluteCameraPos);
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicSorter;writeIndexBuffer(Lnet/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/CombinedCameraPos;Z)V"), method = "execute(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lnet/caffeinemc/mods/sodium/client/util/task/CancellationToken;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkSortOutput;")
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicSorter;writeIndexBuffer(Lnet/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/CombinedCameraPos;)V"), method = "execute(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lnet/caffeinemc/mods/sodium/client/util/task/CancellationToken;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkSortOutput;", cancellable = true)
 	private void handleResorting(
 		ChunkBuildContext context,
 		CancellationToken cancellationToken,
 		CallbackInfoReturnable<ChunkSortOutput> cir,
-		@Local(name = "profiler") ProfilerFiller profiler,
-		@Share("resort") LocalRef<Boolean> shouldResort
+		@Local(name = "profiler") ProfilerFiller profiler
 	) {
 		GlowcaseLevelRenderer levelRenderer = GlowcaseLevelRenderer.getInstance();
 		var visibleSections = levelRenderer.visibleSections();
-		long sectionNode = render.getPosition().asLong();
+		long sectionNode = this.section.getPosition().asLong();
 		if (!visibleSections.isVisible(sectionNode)) return;
 		profiler.push("baked_be");
 
@@ -64,6 +61,7 @@ public abstract class ChunkBuilderSortingTaskMixin extends ChunkBuilderTask<Chun
 
 			while (!success) {
 				if (cancellationToken.isCancelled()) {
+					// In theory, this would never be reached - SkyNotTheLimit
 					indexBuffer.close();
 					bufferBuilder.clear();
 					BakedBESortingTask.indexBufferPool.release(bufferBuilder);

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/EntityRendererMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/EntityRendererMixin.java
@@ -3,7 +3,6 @@ package dev.hephaestus.glowcase.mixin.client.bakedbe.sodium;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import dev.hephaestus.glowcase.client.sodium.AsyncEntityRenderer;
-import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.caffeinemc.mods.sodium.client.render.immediate.model.EntityRenderer;
 import net.caffeinemc.mods.sodium.client.render.immediate.model.ModelCuboid;

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/RenderSectionManagerMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/RenderSectionManagerMixin.java
@@ -9,7 +9,6 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.hephaestus.glowcase.client.render.bakedbe.level.GlowcaseLevelRenderer;
 import dev.hephaestus.glowcase.client.sodium.BakedBESortingTask;
 import dev.hephaestus.glowcase.mixinsupport.sodium.RenderSectionManagerExtension;
-import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
 import net.caffeinemc.mods.sodium.client.render.chunk.ChunkUpdateTypes;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
@@ -19,6 +18,7 @@ import net.caffeinemc.mods.sodium.client.render.chunk.compile.estimation.MeshTas
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.estimation.UploadDurationEstimator;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderSortingTask;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderTask;
+import net.caffeinemc.mods.sodium.client.render.chunk.storage.SectionStorage;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import org.joml.Vector3dc;
@@ -42,20 +42,21 @@ public abstract class RenderSectionManagerMixin implements RenderSectionManagerE
 	@Shadow private @Final JobDurationEstimator jobDurationEstimator;
 	@Shadow private @Final MeshTaskSizeEstimator meshTaskSizeEstimator;
 	@Shadow private @Final UploadDurationEstimator jobUploadDurationEstimator;
-	@Shadow private @Final Long2ReferenceMap<RenderSection> sectionByPosition;
+	@Shadow private @Final SectionStorage renderSections;
 	@Shadow private @Nullable Vector3dc cameraPosition;
 	@Shadow private int frame;
 
 	@Shadow protected abstract boolean shouldPrioritizeTask(RenderSection section, float distance);
 	@Shadow protected abstract boolean upgradePendingUpdate(RenderSection section, int updateType);
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult;successfully(Ljava/lang/Object;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult;"), method = "submitSectionTask")
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult;successfully(Ljava/lang/Object;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult;"), method = "submitSectionTask(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobCollector;Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;ILnet/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/UploadResourceBudget;Z)V")
 	private void clearEmptySection(CallbackInfo ci, @Local(argsOnly = true, name = "section") RenderSection section) {
 		GlowcaseLevelRenderer.getInstance().updateAndCompile(section.getPosition().asLong(), null, null);
 	}
 
+	@Override
 	public void glowcase$scheduleBakedBESort(long sectionPos) {
-		RenderSection section = this.sectionByPosition.get(sectionPos);
+		RenderSection section = this.renderSections.getConsistent(sectionPos); // TODO: check
 
 		if (section != null) {
 			int pendingUpdate = BAKED_BE_SORT;
@@ -67,7 +68,7 @@ public abstract class RenderSectionManagerMixin implements RenderSectionManagerE
 		}
 	}
 
-	@WrapOperation(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager;createSortTask(Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;I)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderSortingTask;"), method = "submitSectionTask")
+	@WrapOperation(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager;createSortTask(Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;I)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderSortingTask;"), method = "submitSectionTask(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobCollector;Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;ILnet/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/UploadResourceBudget;Z)V")
 	private ChunkBuilderSortingTask checkIfBakedBEResort(
 		RenderSectionManager instance,
 		RenderSection render,
@@ -80,7 +81,7 @@ public abstract class RenderSectionManagerMixin implements RenderSectionManagerE
 
 	@Definition(id = "createSortTask", method = "Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager;createSortTask(Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;I)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderSortingTask;")
 	@Expression("? = ?.createSortTask(?, ?)")
-	@Inject(at = @At(value = "MIXINEXTRAS:EXPRESSION", shift = At.Shift.AFTER), method = "submitSectionTask")
+	@Inject(at = @At(value = "MIXINEXTRAS:EXPRESSION", shift = At.Shift.AFTER), method = "submitSectionTask(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobCollector;Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;ILnet/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/UploadResourceBudget;Z)V")
 	private void createBakedBESortTask(
 		CallbackInfo ci,
 		@Local(argsOnly = true, name = "type") int type,
@@ -89,11 +90,11 @@ public abstract class RenderSectionManagerMixin implements RenderSectionManagerE
 	) {
 		if (task.get() != null || (type & BAKED_BE_SORT) == 0) return;
 
-		task.set(createBakedBESortTask(section, this.frame));
+		task.set(glowcase$createBakedBESortTask(section, this.frame));
 	}
 
 	@Unique
-	public BakedBESortingTask createBakedBESortTask(RenderSection render, int frame) {
+	public BakedBESortingTask glowcase$createBakedBESortTask(RenderSection render, int frame) {
 		var task = BakedBESortingTask.create(render, frame, this.cameraPosition);
 		if (task != null) {
 			task.calculateEstimations(this.jobDurationEstimator, this.meshTaskSizeEstimator, this.jobUploadDurationEstimator);

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/RenderSectionMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/RenderSectionMixin.java
@@ -1,7 +1,9 @@
 package dev.hephaestus.glowcase.mixin.client.bakedbe.sodium;
 
 import dev.hephaestus.glowcase.client.render.bakedbe.level.GlowcaseLevelRenderer;
+import dev.hephaestus.glowcase.client.sodium.BakedBESortingTask;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
+import net.caffeinemc.mods.sodium.client.render.chunk.compile.BuilderTaskOutput;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.SectionPos;
@@ -22,5 +24,12 @@ public class RenderSectionMixin {
 	@Inject(at = @At("RETURN"), method = "clearRenderState")
 	private void onSectionReleased(CallbackInfoReturnable<Boolean> cir) {
 		GlowcaseLevelRenderer.getInstance().releaseSection(SectionPos.asLong(chunkX, chunkY, chunkZ));
+	}
+
+	@Inject(method = "addBuildOutput", at = @At("HEAD"), cancellable = true)
+	private void fixInstanceofByBlocking(BuilderTaskOutput output, CallbackInfoReturnable<Boolean> cir) {
+		if (output instanceof BakedBESortingTask.Output) {
+			cir.setReturnValue(false);
+		}
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/VisibleChunkCollectorMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/bakedbe/sodium/VisibleChunkCollectorMixin.java
@@ -3,10 +3,10 @@ package dev.hephaestus.glowcase.mixin.client.bakedbe.sodium;
 import dev.hephaestus.glowcase.client.render.bakedbe.level.GlowcaseLevelRenderer;
 import dev.hephaestus.glowcase.client.render.bakedbe.level.VisibleSections;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.RenderListProvider;
-import net.caffeinemc.mods.sodium.client.render.chunk.lists.SectionCollector;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.SortedRenderLists;
+import net.caffeinemc.mods.sodium.client.render.chunk.lists.VisibleChunkCollector;
+import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -20,16 +20,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @SuppressWarnings("JavadocDeclaration")
 @Environment(EnvType.CLIENT)
-@Mixin(SectionCollector.class)
-public abstract class SectionCollectorMixin implements RenderListProvider {
+@Mixin(VisibleChunkCollector.class)
+public abstract class VisibleChunkCollectorMixin implements RenderListProvider {
 	// We can't tell how big this will be, so we'll just use the last size
 	private final @Unique LongArrayList sortedSections = new LongArrayList(GlowcaseLevelRenderer.getInstance().visibleSections().indexSize());
 
-	@Inject(at = @At("RETURN"), method = "visit(Lnet/caffeinemc/mods/sodium/client/render/chunk/RenderSection;I)V")
-	private void addSectionPos(RenderSection section, int flags, CallbackInfo ci) {
-		sortedSections.add(section.getPosition().asLong());
+	@Inject(at = @At("RETURN"), method = "visit")
+	private void addSectionPos(int x, int y, int z, CallbackInfo ci) {
+		sortedSections.add(RenderRegion.key(x, y, z));
 	}
-
 
 	/**
 	 * @author Luna (Awakened Redstone)

--- a/src/main/resources/glowcase.mixins.json
+++ b/src/main/resources/glowcase.mixins.json
@@ -53,7 +53,7 @@
 		"client.bakedbe.sodium.PoseAccessor",
 		"client.bakedbe.sodium.RenderSectionManagerMixin",
 		"client.bakedbe.sodium.RenderSectionMixin",
-		"client.bakedbe.sodium.SectionCollectorMixin",
+      "client.bakedbe.sodium.VisibleChunkCollectorMixin",
 		"client.bakedbe.sodium.SodiumWorldRendererAccessor",
 		"client.sound.SoundEngineMixin",
 		"client.sound.SoundManagerMixin"


### PR DESCRIPTION
Update sodium and modmenu deps
`Long2ReferenceMap<RenderSection> sectionByPosition` became `SectionStorage renderSections` in https://github.com/CaffeineMC/sodium/commit/7d86fa6814eacc17bcd85a1fcbb39943280ae7a7
`SectionCollector` was removed in https://github.com/CaffeineMC/sodium/commit/a327f636280015ae9103d9e605420f438c043703 and seems to have been functionally replaced by `VisibleChunkCollector`

Testing: uncommented runtime sodium dependency and it works:tm: so I think it's fine (probably)