### PR TITLE
Fix Collection Case Action Sounds Playing for Other Players - Fix #143

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/item/CollectionCaseItem.java
+++ b/src/main/java/dev/hephaestus/glowcase/item/CollectionCaseItem.java
@@ -67,7 +67,7 @@ public class CollectionCaseItem extends Item implements ScrollableItem {
 	@Override
 	public void scroll(ItemStack caseStack, Player player, int amount) {
 		CollectionComponent collection = caseStack.get(Glowcase.COLLECTION_COMPONENT.get());
-		if (collection != null && collection.collected() > 1) {
+		if (collection != null) {
 			if (amount > 0) {
 				for (int i = 0; i < amount; i++) {
 					collection = collection.selectPrevious(!player.isCreative());

--- a/src/main/java/dev/hephaestus/glowcase/item/CollectionCaseItem.java
+++ b/src/main/java/dev/hephaestus/glowcase/item/CollectionCaseItem.java
@@ -3,7 +3,6 @@ package dev.hephaestus.glowcase.item;
 import dev.hephaestus.glowcase.Glowcase;
 import dev.hephaestus.glowcase.item.component.CollectionComponent;
 import dev.hephaestus.glowcase.util.CollectableStack;
-import java.util.List;
 import java.util.function.Consumer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -31,11 +30,11 @@ public class CollectionCaseItem extends Item implements ScrollableItem {
 				if (!retrievedStack.isEmpty() && collection.isSelectedCollected()) { // Retrieve Collectable
 					otherStackSetter.accept(retrievedStack);
 					caseStack.set(Glowcase.COLLECTION_COMPONENT.get(), collection.retrieveSelectedStack(player.isCreative()));
-					playRetrieveSound(player);
+					if (player.isLocalPlayer()) playRetrieveSound(player);
 					return true;
 				} else if (player.isCreative() && tooltipVisible && collection.hasSelection()) { // Remove Collectable
 					caseStack.set(Glowcase.COLLECTION_COMPONENT.get(), collection.withoutSelectedStack());
-					playRemoveSound(player);
+					if (player.isLocalPlayer()) playRemoveSound(player);
 					return true;
 				}
 			} else { // Insertion Actions
@@ -43,11 +42,11 @@ public class CollectionCaseItem extends Item implements ScrollableItem {
 				if (collectionIndex != -1) { // Collect Collectable
 					otherStack.shrink(collection.collectables().get(collectionIndex).getStack().getCount());
 					caseStack.set(Glowcase.COLLECTION_COMPONENT.get(), collection.collectStack(collectionIndex));
-					playCollectSound(player);
+					if (player.isLocalPlayer()) playCollectSound(player);
 					return true;
 				} else if (player.isCreative()) { // Add Collectable
 					caseStack.set(Glowcase.COLLECTION_COMPONENT.get(), collection.withStackAfterSelection(otherStack));
-					playAddSound(player);
+					if (player.isLocalPlayer()) playAddSound(player);
 					return true;
 				}
 			}
@@ -68,7 +67,7 @@ public class CollectionCaseItem extends Item implements ScrollableItem {
 	@Override
 	public void scroll(ItemStack caseStack, Player player, int amount) {
 		CollectionComponent collection = caseStack.get(Glowcase.COLLECTION_COMPONENT.get());
-		if (collection != null) {
+		if (collection != null && collection.collected() > 1) {
 			if (amount > 0) {
 				for (int i = 0; i < amount; i++) {
 					collection = collection.selectPrevious(!player.isCreative());
@@ -80,14 +79,12 @@ public class CollectionCaseItem extends Item implements ScrollableItem {
 				}
 				caseStack.set(Glowcase.COLLECTION_COMPONENT.get(), collection);
 			}
-			playScrollSound(player);
+			if (player.isLocalPlayer()) playScrollSound(player);
 		}
 	}
 
 	@Override
 	public void appendHoverText(ItemStack stack, TooltipContext context, TooltipDisplay displayComponent, Consumer<Component> textConsumer, TooltipFlag type) {
-		super.appendHoverText(stack, context, displayComponent, textConsumer, type);
-		
 		CollectionComponent collection = stack.get(Glowcase.COLLECTION_COMPONENT.get());
 		textConsumer.accept(Component.translatable("item.glowcase.collection_case.tooltip.0").withStyle(ChatFormatting.GRAY));
 		if (type.isCreative()) textConsumer.accept(Component.translatable("item.glowcase.collection_case.tooltip.creative.0").withStyle(ChatFormatting.DARK_GRAY));

--- a/src/main/java/dev/hephaestus/glowcase/item/CollectionCaseItem.java
+++ b/src/main/java/dev/hephaestus/glowcase/item/CollectionCaseItem.java
@@ -85,6 +85,8 @@ public class CollectionCaseItem extends Item implements ScrollableItem {
 
 	@Override
 	public void appendHoverText(ItemStack stack, TooltipContext context, TooltipDisplay displayComponent, Consumer<Component> textConsumer, TooltipFlag type) {
+		super.appendHoverText(stack, context, displayComponent, textConsumer, type);
+
 		CollectionComponent collection = stack.get(Glowcase.COLLECTION_COMPONENT.get());
 		textConsumer.accept(Component.translatable("item.glowcase.collection_case.tooltip.0").withStyle(ChatFormatting.GRAY));
 		if (type.isCreative()) textConsumer.accept(Component.translatable("item.glowcase.collection_case.tooltip.creative.0").withStyle(ChatFormatting.DARK_GRAY));


### PR DESCRIPTION
Simple fix for #143, where sounds from the Collection Case (adding/removing items, scrolling) would be played for nearby players. Nothing is needed for making scrolling on the client, as Collection Case actions are already client-sided (I initially assumed they weren't when Tomate and I discovered this bug, which is why it was mentioned)

I also tried to figure out #132, but it's a much more convoluted problem than you'd think. My attempted solution was "if collectable is selected and (collected or player is in creative)", bolden. 

However, The `type.isCreative()` method in the tooltip method is not checking whether the player is in creative mode, but rather if the item is in the creative mode search screen. I don't think there is anywhere to access the information we need without mixins or a separate class to call the client Minecraft instance, so I left it. 

With that, I initially fixed a bug where players can scroll through the Collection Case even if there's nothing to scroll through, but because of #132, I've opted to un-fix that for now.